### PR TITLE
[Fix] (provider) 纠正无法正确获取当前使用的模型情况

### DIFF
--- a/main.py
+++ b/main.py
@@ -146,8 +146,8 @@ class QQGroupDailyAnalysis(Star):
 
             yield event.plain_result(f"📊 已获取{len(messages)}条消息，正在进行智能分析...")
 
-            # 进行分析
-            analysis_result = await message_analyzer.analyze_messages(messages, group_id)
+            # 进行分析 - 传递 unified_msg_origin 以获取正确的 LLM 提供商
+            analysis_result = await message_analyzer.analyze_messages(messages, group_id, event.unified_msg_origin)
 
             # 检查分析结果
             if not analysis_result or not analysis_result.get("statistics"):

--- a/src/analysis/llm_analyzer.py
+++ b/src/analysis/llm_analyzer.py
@@ -20,7 +20,21 @@ class LLMAnalyzer:
         self.config_manager = config_manager
 
     async def _call_provider_with_retry(self, provider, prompt: str, max_tokens: int, temperature: float, umo: str = None):
-        """调用LLM提供者，带超时、重试与退避。支持自定义服务商。"""
+        """
+        调用LLM提供者，带超时、重试与退避。支持自定义服务商。
+
+        Args:
+            provider: LLM服务商实例或None。
+            prompt (str): 输入的提示语。
+            max_tokens (int): 最大生成token数。
+            temperature (float): 采样温度。
+            umo (str, optional): 指定使用的模型唯一标识符（Unique Model Object），
+                用于选择特定的LLM服务商或模型。格式通常为字符串，例如 "gpt-3.5-turbo"。
+                如果为None，则使用默认模型。
+
+        Returns:
+            LLM生成的结果。
+        """
         timeout = self.config_manager.get_llm_timeout()
         retries = self.config_manager.get_llm_retries()
         backoff = self.config_manager.get_llm_backoff()

--- a/src/analysis/llm_analyzer.py
+++ b/src/analysis/llm_analyzer.py
@@ -81,8 +81,6 @@ class LLMAnalyzer:
                     # 确保使用当前指定的模型
                     if provider is None:
                         provider = self.context.get_using_provider(umo=umo)
-                        
-                        # 安全地获取 provider ID
                         provider_id = 'unknown'
                         if provider:
                             try:
@@ -90,10 +88,7 @@ class LLMAnalyzer:
                                 provider_id = meta.id
                             except Exception as e:
                                 logger.debug(f"获取提供商ID失败: {e}")
-                        
                         logger.info(f"获取到的 provider ID: {provider_id}")
-                        
-                        # 如果获取失败，尝试使用全局默认提供商或者回退方案
                         if not provider or provider_id == 'unknown':
                             logger.warning(f"获取的提供商不正确 (Provider ID: {provider_id})")
 
@@ -118,7 +113,7 @@ class LLMAnalyzer:
         logger.error(f"LLM请求全部重试失败: {last_exc}")
         return None
 
-    async def analyze_topics(self, messages: List[Dict]) -> Tuple[List[SummaryTopic], TokenUsage]:
+    async def analyze_topics(self, messages: List[Dict], umo: str = None) -> Tuple[List[SummaryTopic], TokenUsage]:
         """使用LLM分析话题"""
         try:
             # 提取文本消息
@@ -203,12 +198,7 @@ class LLMAnalyzer:
 """
 
             # 调用LLM
-            provider = self.context.get_using_provider()
-            if not provider:
-                logger.warning("未配置LLM提供商，跳过话题分析")
-                return [], TokenUsage()
-
-            response = await self._call_provider_with_retry(provider, prompt, max_tokens=10000, temperature=0.6)
+            response = await self._call_provider_with_retry(None, prompt, max_tokens=10000, temperature=0.6, umo=umo)
             if response is None:
                 logger.error("话题分析调用LLM失败: provider返回None（重试失败）")
                 return [], TokenUsage()
@@ -359,7 +349,7 @@ class LLMAnalyzer:
             logger.error(f"正则表达式提取失败: {e}")
             return []
 
-    async def analyze_user_titles(self, messages: List[Dict], user_analysis: Dict) -> Tuple[List[UserTitle], TokenUsage]:
+    async def analyze_user_titles(self, messages: List[Dict], user_analysis: Dict, umo: str = None) -> Tuple[List[UserTitle], TokenUsage]:
         """使用LLM分析用户称号"""
         try:
             # 准备用户数据
@@ -430,12 +420,7 @@ class LLMAnalyzer:
 """
 
             # 调用LLM
-            provider = self.context.get_using_provider()
-            if not provider:
-                logger.warning("未配置LLM提供商，跳过用户称号分析")
-                return [], TokenUsage()
-
-            response = await self._call_provider_with_retry(provider, prompt, max_tokens=1500, temperature=0.5)
+            response = await self._call_provider_with_retry(None, prompt, max_tokens=1500, temperature=0.5, umo=umo)
             if response is None:
                 logger.error("用户称号分析调用LLM失败: provider返回None（重试失败）")
                 return [], TokenUsage()
@@ -477,7 +462,7 @@ class LLMAnalyzer:
             logger.error(f"用户称号分析失败: {e}")
             return [], TokenUsage()
 
-    async def analyze_golden_quotes(self, messages: List[Dict]) -> Tuple[List[GoldenQuote], TokenUsage]:
+    async def analyze_golden_quotes(self, messages: List[Dict], umo: str = None) -> Tuple[List[GoldenQuote], TokenUsage]:
         """使用LLM分析群聊金句"""
         try:
             # 提取有趣的文本消息
@@ -538,12 +523,7 @@ class LLMAnalyzer:
 """
 
             # 调用LLM
-            provider = self.context.get_using_provider()
-            if not provider:
-                logger.warning("未配置LLM提供商，跳过金句分析")
-                return [], TokenUsage()
-
-            response = await self._call_provider_with_retry(provider, prompt, max_tokens=1500, temperature=0.7)
+            response = await self._call_provider_with_retry(None, prompt, max_tokens=1500, temperature=0.7, umo=umo)
             if response is None:
                 logger.error("金句分析调用LLM失败: provider返回None（重试失败）")
                 return [], TokenUsage()

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -28,7 +28,7 @@ class MessageAnalyzer:
         else:
             await self.message_handler.set_bot_qq_id(bot_instance)
 
-    async def analyze_messages(self, messages: List[Dict], group_id: str) -> Dict:
+    async def analyze_messages(self, messages: List[Dict], group_id: str, unified_msg_origin: str = None) -> Dict:
         """完整的消息分析流程"""
         try:
             # 基础统计
@@ -45,20 +45,20 @@ class MessageAnalyzer:
 
             # 话题分析
             if self.config_manager.get_topic_analysis_enabled():
-                topics, topic_tokens = await self.llm_analyzer.analyze_topics(messages)
+                topics, topic_tokens = await self.llm_analyzer.analyze_topics(messages, umo=unified_msg_origin)
                 total_token_usage.prompt_tokens += topic_tokens.prompt_tokens
                 total_token_usage.completion_tokens += topic_tokens.completion_tokens
                 total_token_usage.total_tokens += topic_tokens.total_tokens
 
             # 用户称号分析
             if self.config_manager.get_user_title_analysis_enabled():
-                user_titles, title_tokens = await self.llm_analyzer.analyze_user_titles(messages, user_analysis)
+                user_titles, title_tokens = await self.llm_analyzer.analyze_user_titles(messages, user_analysis, umo=unified_msg_origin)
                 total_token_usage.prompt_tokens += title_tokens.prompt_tokens
                 total_token_usage.completion_tokens += title_tokens.completion_tokens
                 total_token_usage.total_tokens += title_tokens.total_tokens
 
             # 金句分析
-            golden_quotes, quote_tokens = await self.llm_analyzer.analyze_golden_quotes(messages)
+            golden_quotes, quote_tokens = await self.llm_analyzer.analyze_golden_quotes(messages, umo=unified_msg_origin)
             total_token_usage.prompt_tokens += quote_tokens.prompt_tokens
             total_token_usage.completion_tokens += quote_tokens.completion_tokens
             total_token_usage.total_tokens += quote_tokens.total_tokens


### PR DESCRIPTION
根据文档

[fix] (llm_analyer) provider.meta().id 获取 provider_id
[fix] (LLM 提供商) 传递 umo=unified_msg_origin 以获取正确的 LLM 提供商

## Summary by Sourcery

Correct LLM provider detection by propagating unified_msg_origin through analysis calls and logging the provider ID.

Bug Fixes:
- Pass unified_msg_origin (umo) into context.get_using_provider to fix incorrect provider selection
- Retrieve and log provider.meta().id to surface and warn on unknown providers

Enhancements:
- Add unified_msg_origin parameter to _call_provider_with_retry, analyze_topics, analyze_user_titles, analyze_golden_quotes, and analyze_messages methods
- Implement auto_scheduler._get_platform_id to derive platform ID and construct unified_msg_origin for group analysis