### PR TITLE
feat(onebot): 正确识别 QQ 表情包 (subType=1)

### DIFF
--- a/src/infrastructure/platform/adapters/onebot_adapter.py
+++ b/src/infrastructure/platform/adapters/onebot_adapter.py
@@ -259,17 +259,22 @@ class OneBotAdapter(PlatformAdapter):
                 elif seg_type == "image":
                     # QQ 平台: subType=1 表示表情包，通过 raw_data 传递给下游统计
                     sub_type = seg_data.get("subType", seg_data.get("sub_type"))
-                    is_sticker = sub_type is not None and int(sub_type) == 1
+                    # 安全地转换为整数，防止非数字值导致异常
+                    try:
+                        is_sticker = int(sub_type) == 1
+                    except (TypeError, ValueError):
+                        is_sticker = False
+                    # 只在 sub_type 有效时包含在 raw_data 中
+                    raw_data: dict[str, Any] = {"summary": seg_data.get("summary", "")}
+                    if sub_type is not None:
+                        raw_data["sub_type"] = int(sub_type)
                     contents.append(
                         MessageContent(
                             type=MessageContentType.EMOJI
                             if is_sticker
                             else MessageContentType.IMAGE,
                             url=seg_data.get("url", seg_data.get("file", "")),
-                            raw_data={
-                                "sub_type": int(sub_type) if sub_type is not None else None,
-                                "summary": seg_data.get("summary", ""),
-                            },
+                            raw_data=raw_data,
                         )
                     )
 


### PR DESCRIPTION
我仅修改了onebot适配器里面判别表情包的部分，目前在我测试后对功能无影响，并能够正常识别表情包数量。
改前：
<img width="2304" height="8005" alt="88f9bfcba0e7c1d3a59603e8fcb7641a" src="https://github.com/user-attachments/assets/7160a170-ecbd-4c93-99f5-b0c10b93446d" />

改后：
<img width="2304" height="8152" alt="13eee40720c83cdf1a779b47ea60f0b6" src="https://github.com/user-attachments/assets/6784f133-4f54-4f91-8a80-61a5bffbe12a" />

## Summary by Sourcery

Adjust OneBot image message handling to distinguish QQ sticker images from regular images and surface sticker metadata in unified messages.

New Features:
- Treat QQ image segments with subType=1 as emoji-type message contents instead of generic images.
- Expose QQ image segment metadata such as sub_type and summary via the message content raw_data field for downstream processing.