### PR TITLE
fix: 修复图像渲染 HTML 和 Base64 乱码及渲染图片存在超长文本撑爆图片导致消息发送失败问题

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -88,12 +88,6 @@
                 "description": "图片传输使用 Base64 编码",
                 "default": true,
                 "hint": "启用后图片会被转为 Base64 编码传输。关闭后将直接传递文件路径或 URL 给 OneBot 实现端，适用于 go-cqhttp、Lagrange 等支持本地路径的实现，可降低内存占用。"
-            },
-            "enable_analysis_reply": {
-                "type": "bool",
-                "description": "发送文本/表情回复",
-                "default": false,
-                "hint": "开启后，/群分析 将通过发送文本消息提示进度；关闭（默认）则使用表情回应。"
             }
         }
     },

--- a/main.py
+++ b/main.py
@@ -504,14 +504,10 @@ class GroupDailyAnalysis(Star):
         )
         TraceContext.set(trace_id)
 
-        # 表情回应 或 文本提示（二选一，由配置开关控制）
+        # 使用表情回应代替文本回复
         adapter = self.bot_manager.get_adapter(platform_id)
         orig_msg_id = getattr(event.message_obj, "message_id", None)
-        use_text_reply = self.config_manager.get_enable_analysis_reply()
-
-        if use_text_reply:
-            yield event.plain_result("🔍 正在启动分析引擎，正在拉取最近消息...")
-        elif adapter and orig_msg_id:
+        if adapter and orig_msg_id:
             await adapter.set_reaction(event.get_group_id(), orig_msg_id, "🔍")  # 🔍
 
         try:
@@ -528,7 +524,7 @@ class GroupDailyAnalysis(Star):
                     yield event.plain_result("❌ 分析失败，原因未知")
                 return
 
-            if not use_text_reply and adapter and orig_msg_id:
+            if adapter and orig_msg_id:
                 await adapter.set_reaction(
                     event.get_group_id(), orig_msg_id, "📊"
                 )  # 📊

--- a/src/domain/services/message_cleaner_service.py
+++ b/src/domain/services/message_cleaner_service.py
@@ -107,3 +107,39 @@ class MessageCleanerService:
                 cleaned_list.append(new_msg)
 
         return cleaned_list
+
+    @staticmethod
+    def sanitize_chat_text(text: str) -> str:
+        """
+        Remove HTML tags, Base64 data URIs, and control characters from chat text
+        before LLM processing.
+
+        This prevents contaminated data from breaking JSON parsing in LLM responses
+        and causing layout issues in rendered HTML reports.
+
+        Args:
+            text: Raw chat message text
+
+        Returns:
+            Cleaned text with only plain content
+        """
+        if not text:
+            return ""
+
+        # Remove Base64 data URIs first (longer pattern, should be removed before tags)
+        text = re.sub(r"data:[^;]+;base64,[A-Za-z0-9+/=]+", "", text)
+
+        # Remove HTML tags (including self-closing and attributes)
+        text = re.sub(r"<[^>]+>", "", text)
+
+        # Remove control characters (ASCII 0x00-0x1F, 0x7F-0x9F)
+        text = re.sub(r"[\x00-\x1f\x7f-\x9f]", "", text)
+
+        # Normalize Unicode quotes to ASCII equivalents
+        text = text.replace("\u201c", '"').replace("\u201d", '"')  # " "
+        text = text.replace("\u2018", "'").replace("\u2019", "'")  # ' '
+
+        # Clean up extra whitespace from removals
+        text = re.sub(r"\s+", " ", text).strip()
+
+        return text

--- a/src/infrastructure/analysis/analyzers/chat_quality_analyzer.py
+++ b/src/infrastructure/analysis/analyzers/chat_quality_analyzer.py
@@ -6,6 +6,7 @@
 from datetime import datetime
 
 from ....domain.models.data_models import QualityDimension, QualityReview, TokenUsage
+from ....domain.services.message_cleaner_service import MessageCleanerService
 from ....utils.logger import logger
 from ..utils import InfoUtils
 from ..utils.json_utils import extract_quality_with_regex, parse_json_object_response
@@ -79,7 +80,9 @@ class ChatQualityAnalyzer(BaseAnalyzer):
 
             combined_text = "".join(text_parts).strip()
             if combined_text and not combined_text.startswith("/"):
-                text_messages.append(f"[{msg_time}] [{nickname}]: {combined_text}")
+                sanitized_text = MessageCleanerService.sanitize_chat_text(combined_text)
+                if sanitized_text:
+                    text_messages.append(f"[{msg_time}] [{nickname}]: {sanitized_text}")
 
         messages_text = "\n".join(text_messages[:1000])
 

--- a/src/infrastructure/analysis/analyzers/golden_quote_analyzer.py
+++ b/src/infrastructure/analysis/analyzers/golden_quote_analyzer.py
@@ -6,6 +6,7 @@
 from datetime import datetime
 
 from ....domain.models.data_models import GoldenQuote, TokenUsage
+from ....domain.services.message_cleaner_service import MessageCleanerService
 from ....utils.logger import logger
 from ..utils import InfoUtils
 from ..utils.json_utils import extract_golden_quotes_with_regex
@@ -54,8 +55,12 @@ class GoldenQuoteAnalyzer(BaseAnalyzer):
             return ""
 
         # 构建消息文本 (用 [user_id] 替代 nickname 以确保回填 100% 准确，避免 Emoji 等干扰)
+        # 应用 sanitize_chat_text 清洗 HTML 标签和 Base64 数据
         messages_text = "\n".join(
-            [f"[{msg['time']}] [{msg['user_id']}]: {msg['content']}" for msg in data]
+            [
+                f"[{msg['time']}] [{msg['user_id']}]: {MessageCleanerService.sanitize_chat_text(msg['content'])}"
+                for msg in data
+            ]
         )
 
         max_golden_quotes = self.get_max_count()

--- a/src/infrastructure/analysis/analyzers/topic_analyzer.py
+++ b/src/infrastructure/analysis/analyzers/topic_analyzer.py
@@ -7,6 +7,7 @@ import re
 from datetime import datetime
 
 from ....domain.models.data_models import SummaryTopic, TokenUsage
+from ....domain.services.message_cleaner_service import MessageCleanerService
 from ....utils.logger import logger
 from ..utils import InfoUtils
 from ..utils.json_utils import extract_topics_with_regex
@@ -149,9 +150,10 @@ class TopicAnalyzer(BaseAnalyzer):
 
         # 构建消息文本
         # 使用用户提供的 ID-Only 格式: [HH:MM] [用户ID]: 消息内容
+        # 应用 sanitize_chat_text 清洗 HTML 标签和 Base64 数据
         messages_text = "\n".join(
             [
-                f"[{msg['time']}] [{msg['user_id']}]: {msg['content']}"
+                f"[{msg['time']}] [{msg['user_id']}]: {MessageCleanerService.sanitize_chat_text(msg['content'])}"
                 for msg in text_messages
             ]
         )

--- a/src/infrastructure/analysis/analyzers/user_title_analyzer.py
+++ b/src/infrastructure/analysis/analyzers/user_title_analyzer.py
@@ -4,6 +4,7 @@
 """
 
 from ....domain.models.data_models import TokenUsage, UserTitle
+from ....domain.services.message_cleaner_service import MessageCleanerService
 from ....utils.logger import logger
 from ..utils.json_utils import extract_user_titles_with_regex
 from .base_analyzer import BaseAnalyzer
@@ -51,12 +52,15 @@ class UserTitleAnalyzer(BaseAnalyzer):
             return ""
 
         # 构建用户数据文本
+        # 应用 sanitize_chat_text 清洗 HTML 标签和 Base64 数据
         users_text = "\n".join(
             [
-                f"- {user['name']} (ID:{user['user_id']}): "
-                f"发言{user['message_count']}条, 平均{user['avg_chars']}字, "
-                f"表情比例{user['emoji_ratio']}, 夜间发言比例{user['night_ratio']}, "
-                f"回复比例{user['reply_ratio']}"
+                (
+                    f"- {MessageCleanerService.sanitize_chat_text(user['name'])} (ID:{user['user_id']}): "
+                    f"发言{user['message_count']}条, 平均{user['avg_chars']}字, "
+                    f"表情比例{user['emoji_ratio']}, 夜间发言比例{user['night_ratio']}, "
+                    f"回复比例{user['reply_ratio']}"
+                )
                 for user in user_summaries
             ]
         )

--- a/src/infrastructure/analysis/utils/json_utils.py
+++ b/src/infrastructure/analysis/utils/json_utils.py
@@ -9,6 +9,57 @@ import re
 from ....utils.logger import logger
 
 
+def _extract_json_balanced(text: str, open_char: str, close_char: str) -> str | None:
+    """
+    Extract the first complete JSON array or object from text, handling strings correctly.
+
+    This function properly handles:
+    - Strings containing ] or } characters
+    - Escaped characters within strings
+    - Nested structures
+
+    Args:
+        text: Text containing JSON
+        open_char: Opening bracket/brace ('[' or '{')
+        close_char: Closing bracket/brace (']' or '}')
+
+    Returns:
+        The extracted JSON string, or None if not found
+    """
+    start = text.find(open_char)
+    if start == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escape_next = False
+
+    for i, char in enumerate(text[start:], start):
+        if escape_next:
+            escape_next = False
+            continue
+
+        if char == "\\":
+            escape_next = True
+            continue
+
+        if char == '"' and not escape_next:
+            in_string = not in_string
+            continue
+
+        if in_string:
+            continue
+
+        if char == open_char:
+            depth += 1
+        elif char == close_char:
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+
+    return None
+
+
 def fix_json(text: str) -> str:
     """
     修复JSON格式问题，包括中文符号替换
@@ -28,49 +79,32 @@ def fix_json(text: str) -> str:
         text = text.replace("\n", " ").replace("\r", " ")
         text = re.sub(r"\s+", " ", text)
 
-        # 3. 替换中文符号为英文符号（修复）
-        # 中文引号 -> 英文引号
-        text = text.replace("“", '"').replace("”", '"')
-        text = text.replace("‘", "'").replace("’", "'")
-        # 中文逗号 -> 英文逗号
-        text = text.replace("，", ",")
-        # 中文冒号 -> 英文冒号
-        text = text.replace("：", ":")
-        # 中文括号 -> 英文括号
-        text = text.replace("（", "(").replace("）", ")")
-        text = text.replace("【", "[").replace("】", "]")
+        # 3. 替换中文符号为英文符号
+        text = text.replace("\u201c", '"').replace("\u201d", '"')
+        text = text.replace("\u2018", "'").replace("\u2019", "'")
+        text = text.replace("\uff0c", ",")
+        text = text.replace("\uff1a", ":")
+        text = text.replace("\uff08", "(").replace("\uff09", ")")
+        text = text.replace("\u3010", "[").replace("\u3011", "]")
 
-        # 4. 处理字符串内容中的特殊字符
-        # 转义字符串内的双引号
-        def escape_quotes_in_strings(match):
-            content = match.group(1)
-            # 转义内部的双引号
-            content = content.replace('"', '\\"')
-            return f'"{content}"'
-
-        # 先处理字段值中的引号
-        text = re.sub(r'"([^"]*(?:"[^"]*)*)"', escape_quotes_in_strings, text)
-
-        # 5. 修复截断的JSON
+        # 4. 修复截断的JSON
         if not text.endswith("]"):
             last_complete = text.rfind("}")
             if last_complete > 0:
                 text = text[: last_complete + 1] + "]"
 
-        # 6. 修复常见的JSON格式问题
-        # 1. 修复缺失的逗号
+        # 5. 修复缺失的逗号
         text = re.sub(r"}\s*{", "}, {", text)
 
-        # 2. 确保字段名有引号（仅在对象开始或逗号后，避免破坏字符串值）
+        # 6. 确保字段名有引号
         def quote_field_names(match):
             prefix = match.group(1)
             key = match.group(2)
             return f'{prefix}"{key}":'
 
-        # 只在 { 或 , 后面匹配字段名，避免在字符串值中误匹配
         text = re.sub(r"([{,]\s*)([a-zA-Z_][a-zA-Z0-9_]*)\s*:", quote_field_names, text)
 
-        # 3. 移除多余的逗号
+        # 7. 移除多余的逗号
         text = re.sub(r",\s*}", "}", text)
         text = re.sub(r",\s*]", "]", text)
 
@@ -96,14 +130,13 @@ def parse_json_response(
     """
     fixed_json_text = None
     try:
-        # 1. 提取JSON部分
-        json_match = re.search(r"\[.*?\]", result_text, re.DOTALL)
-        if not json_match:
+        # 1. 提取JSON数组（使用balanced extraction处理字符串内的]字符）
+        json_text = _extract_json_balanced(result_text, "[", "]")
+        if not json_text:
             error_msg = f"{data_type}响应中未找到JSON格式"
             logger.warning(error_msg)
             return False, None, error_msg
 
-        json_text = json_match.group()
         logger.debug(f"{data_type}分析JSON原文: {json_text[:500]}...")
 
         # 2. 尝试直接解析
@@ -162,17 +195,16 @@ def parse_json_object_response(
         raw_text = re.sub(r"```\s*$", "", raw_text)
         raw_text = raw_text.strip()
 
-        # 2. 提取 JSON 对象
-        json_match = re.search(r"\{.*\}", raw_text, re.DOTALL)
-        if not json_match:
+        # 2. 提取 JSON 对象（使用balanced extraction处理字符串内的}字符）
+        json_text = _extract_json_balanced(raw_text, "{", "}")
+        if not json_text:
             error_msg = f"{data_type}响应中未找到JSON对象"
             logger.warning(error_msg)
             return False, None, error_msg
 
-        json_text = json_match.group()
         logger.debug(f"{data_type}分析JSON原文: {json_text[:500]}...")
 
-        # 3. 尝试直接解析（保留原始文本，避免中文引号被破坏）
+        # 3. 尝试直接解析
         try:
             data = json.loads(json_text)
             logger.info(f"{data_type}直接解析成功")
@@ -182,10 +214,10 @@ def parse_json_object_response(
 
         # 4. 使用 fix_json 修复后重试
         fixed_json = fix_json(json_text)
-        fixed_match = re.search(r"\{.*\}", fixed_json, re.DOTALL)
-        if fixed_match:
+        fixed_text = _extract_json_balanced(fixed_json, "{", "}")
+        if fixed_text:
             try:
-                data = json.loads(fixed_match.group())
+                data = json.loads(fixed_text)
                 logger.info(f"{data_type}修复后解析成功")
                 return True, data, None
             except json.JSONDecodeError as e:

--- a/src/infrastructure/config/config_manager.py
+++ b/src/infrastructure/config/config_manager.py
@@ -466,15 +466,6 @@ class ConfigManager:
         """获取是否使用用户群名片"""
         return self._get_group("basic").get("enable_user_card", False)
 
-    def get_enable_analysis_reply(self) -> bool:
-        """获取是否在群分析完成后发送文本回复"""
-        return self._get_group("basic").get("enable_analysis_reply", False)
-
-    def set_enable_analysis_reply(self, enabled: bool):
-        """设置是否在群分析完成后发送文本回复"""
-        self._ensure_group("basic")["enable_analysis_reply"] = enabled
-        self.config.save_config()
-
     # ========== 群文件/群相册上传配置 ==========
 
     def get_enable_group_file_upload(self) -> bool:

--- a/src/infrastructure/reporting/templates/format/image_template.html
+++ b/src/infrastructure/reporting/templates/format/image_template.html
@@ -27,6 +27,9 @@
         }
 
         body {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
             background-color: var(--bg-body);
             color: var(--text-main);
@@ -77,6 +80,9 @@
         }
 
         .section {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             margin-bottom: 50px;
         }
 
@@ -85,6 +91,9 @@
         }
 
         .section-title {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: 'Noto Serif SC', serif;
             font-size: 1.5em;
             font-weight: 600;
@@ -95,6 +104,9 @@
         }
 
         .section-title::before {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             content: '';
             position: absolute;
             left: 0;
@@ -136,6 +148,8 @@
         }
 
         .stat-label {
+            word-wrap: break-word;
+            word-break: break-all;
             font-size: 0.75em;
             color: var(--text-muted);
             font-weight: 500;
@@ -280,6 +294,9 @@
         }
 
         .topic-title {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: 'Noto Serif SC', serif;
             font-weight: 600;
             color: var(--text-main);
@@ -296,6 +313,9 @@
         }
 
         .topic-detail {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             color: #444;
             line-height: 1.6;
             font-size: 0.9em;
@@ -382,6 +402,9 @@
         }
 
         .user-reason {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             color: var(--text-muted);
             font-size: 0.85em;
             font-weight: 500;
@@ -401,6 +424,9 @@
         }
 
         .quote-content {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: 'Noto Serif SC', serif;
             font-size: 1.1em;
             color: var(--text-main);
@@ -419,6 +445,9 @@
         }
 
         .quote-reason {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-size: 0.75em;
             color: var(--text-muted);
             background: rgba(0, 0, 0, 0.03);
@@ -443,6 +472,9 @@
         /* Responsive */
         @media (max-width: 600px) {
             body {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
                 padding: 15px;
             }
 
@@ -468,6 +500,9 @@
             }
 
             .user-reason {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
                 padding-left: 0;
                 margin-top: 10px;
             }

--- a/src/infrastructure/reporting/templates/format/quote_item.html
+++ b/src/infrastructure/reporting/templates/format/quote_item.html
@@ -5,7 +5,7 @@
     <div class="quote-item">
         <div class="quote-content">"{{ quote.content }}"</div>
         <div class="quote-author">—— {{ quote.sender }}</div>
-        <div class="quote-reason">{{ quote.reason }}</div>
+        <div class="quote-reason">{{ quote.reason | safe }}</div>
     </div>
     {% endfor %}
 </div>

--- a/src/infrastructure/reporting/templates/hack/image_template.html
+++ b/src/infrastructure/reporting/templates/hack/image_template.html
@@ -35,6 +35,9 @@
         }
 
         body {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             margin: 0;
             background-color: var(--bg-deep);
             color: var(--text-primary);
@@ -50,6 +53,9 @@
         }
 
         body::before {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             content: "";
             position: fixed;
             top: 0;
@@ -158,6 +164,9 @@
         }
 
         .comment {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             color: var(--text-secondary);
         }
 
@@ -219,6 +228,9 @@
         }
 
         .stat-label {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: var(--font-mono);
             color: var(--text-secondary);
             font-size: 0.85rem;
@@ -229,11 +241,17 @@
         }
 
         .stat-label::before {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             content: '>';
             color: var(--accent-orange);
         }
 
         .stat-value {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-size: 3.5rem;
             font-weight: 800;
             color: var(--accent-orange);
@@ -263,6 +281,9 @@
         }
 
         .section-header {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: var(--font-mono);
             font-size: 1.1rem;
             margin-bottom: 25px;
@@ -274,6 +295,9 @@
 
         /* Code Block Container */
         .code-block {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             background: rgba(20, 20, 20, 0.8);
             border: 1px solid rgba(255, 153, 0, 0.15);
             padding: 30px;
@@ -400,11 +424,17 @@
         }
 
         .user-info h4 {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             margin: 0 0 5px;
             font-size: 1.1rem;
         }
 
         .tag {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: var(--font-mono);
             font-size: 0.75rem;
             padding: 2px 8px;
@@ -414,12 +444,18 @@
         }
 
         .tag.mbti {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             color: #ffcc00;
             border-color: rgba(255, 204, 0, 0.3);
             background: rgba(255, 204, 0, 0.05);
         }
 
         .tag.title {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             color: var(--accent-blue);
             border-color: rgba(51, 153, 255, 0.3);
             background: rgba(51, 153, 255, 0.05);
@@ -438,6 +474,9 @@
         }
 
         .topic-title {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-weight: bold;
             font-size: 1.5rem;
             margin-bottom: 12px;
@@ -477,6 +516,9 @@
         }
 
         .quote-text {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-style: italic;
             font-size: 1.1rem;
             color: var(--accent-orange);
@@ -493,6 +535,9 @@
 
         /* Footer */
         footer {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             margin-top: 80px;
             padding-top: 40px;
             border-top: 1px solid var(--border-color);

--- a/src/infrastructure/reporting/templates/hack/quote_item.html
+++ b/src/infrastructure/reporting/templates/hack/quote_item.html
@@ -16,7 +16,7 @@
         <div class="quote-body">
             <div class="quote-text">"{{ quote.content }}"</div>
             <div class="quote-author">-- {{ quote.sender }}</div>
-            <div class="comment" style="font-size: 0.8rem;">// Reason: {{ quote.reason }}</div>
+            <div class="comment" style="font-size: 0.8rem;">// Reason: {{ quote.reason | safe }}</div>
         </div>
     </div>
     {% endfor %}

--- a/src/infrastructure/reporting/templates/retro_futurism/image_template.html
+++ b/src/infrastructure/reporting/templates/retro_futurism/image_template.html
@@ -58,6 +58,9 @@
         }
 
         body {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             margin: 0;
             background-color: var(--c-bg);
             color: var(--c-text);
@@ -315,6 +318,9 @@
 
         /* Section Labels */
         .section-label {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             grid-column: span 12;
             font-family: var(--font-display);
             font-size: 3.5rem;
@@ -329,6 +335,9 @@
         }
 
         .section-label span {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             background: var(--c-text);
             color: var(--c-bg);
             padding: 8px 20px;
@@ -348,6 +357,9 @@
         }
 
         .stat-label {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: var(--font-mono);
             font-size: 0.9rem;
             font-weight: bold;
@@ -359,6 +371,9 @@
         }
 
         .stat-value {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: var(--font-display);
             font-size: 5rem;
             color: var(--c-accent);
@@ -476,6 +491,9 @@
         }
 
         .topic-title {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: var(--font-display);
             font-size: 3rem;
             margin: 0 0 20px;
@@ -493,6 +511,9 @@
         }
 
         .topic-detail {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-size: 1.4rem;
             line-height: 1.8;
             color: #333;
@@ -557,6 +578,9 @@
         }
 
         .title-reason {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-size: 1.2rem;
             line-height: 1.6;
             margin-top: 15px;
@@ -601,6 +625,9 @@
         }
 
         .quote-content {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: "JetBrains Mono", monospace;
             font-size: 1.6rem;
             line-height: 1.6;
@@ -610,6 +637,9 @@
         }
 
         .quote-content::before {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             content: '"';
             position: absolute;
             left: -20px;
@@ -628,6 +658,9 @@
         }
 
         .quote-reason-small {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-size: 1rem;
             color: #666;
             margin-top: 10px;
@@ -636,6 +669,9 @@
 
         /* Footer */
         footer {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             margin-top: 100px;
             padding: 60px 0;
             border-top: 8px solid var(--c-text);

--- a/src/infrastructure/reporting/templates/retro_futurism/quote_item.html
+++ b/src/infrastructure/reporting/templates/retro_futurism/quote_item.html
@@ -13,7 +13,7 @@
     <div class="quote-body">
         <div class="quote-content">{{ quote.content }}</div>
         <div class="quote-author">ORIGIN: {{ quote.sender }}</div>
-        <div class="quote-reason-small">ANALYSIS // {{ quote.reason }}</div>
+        <div class="quote-reason-small">ANALYSIS // {{ quote.reason | safe }}</div>
     </div>
 </section>
 {% endfor %}

--- a/src/infrastructure/reporting/templates/scrapbook/image_template.html
+++ b/src/infrastructure/reporting/templates/scrapbook/image_template.html
@@ -161,6 +161,9 @@
         }
 
         body {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: var(--font-body);
             color: var(--ink-primary);
             background-color: var(--bg-paper);
@@ -340,6 +343,9 @@
         }
 
         .section-title {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: var(--font-title);
             font-size: 1.5rem;
             margin-bottom: 15px;
@@ -349,6 +355,9 @@
         }
 
         .section-title .doodle {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             color: var(--accent-orange);
             font-size: 1.3em;
         }
@@ -557,6 +566,9 @@
         }
 
         .topic-title {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: var(--font-title);
             font-size: 1.5rem;
             margin-right: 10px;
@@ -565,14 +577,23 @@
         }
 
         .topic-item:nth-child(even) .topic-title {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             background: linear-gradient(transparent 60%, var(--color-blue) 60%);
         }
 
         .topic-item:nth-child(3n) .topic-title {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             background: linear-gradient(transparent 60%, var(--color-green) 60%);
         }
 
         .topic-detail {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: var(--font-hand);
             color: #666;
             font-size: 1.2rem;

--- a/src/infrastructure/reporting/templates/simple/image_template.html
+++ b/src/infrastructure/reporting/templates/simple/image_template.html
@@ -6,11 +6,17 @@
     <title>Simple Report</title>
     <style>
         body {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: sans-serif;
             padding: 20px;
         }
 
         .section {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             margin-bottom: 20px;
             border: 1px solid #ccc;
             padding: 10px;

--- a/src/infrastructure/reporting/templates/simple/quote_item.html
+++ b/src/infrastructure/reporting/templates/simple/quote_item.html
@@ -8,7 +8,7 @@
             — {{ quote.sender }}
         </div>
         <div style="text-align: right; font-size: 0.7em; color: #888;">
-            入选理由: {{ quote.reason }}
+            入选理由: {{ quote.reason | safe }}
         </div>
     </div>
     {% endfor %}

--- a/src/infrastructure/reporting/templates/spring_festival/image_template.html
+++ b/src/infrastructure/reporting/templates/spring_festival/image_template.html
@@ -32,6 +32,9 @@
         }
 
         body {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             margin: 0;
             background-color: var(--red-festive);
             color: var(--text-main);
@@ -328,6 +331,9 @@
         }
 
         .sf-topic-title {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: var(--font-heading);
             font-size: 1.8rem;
             color: var(--red-festive);
@@ -342,6 +348,9 @@
         }
 
         .sf-topic-detail {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             line-height: 1.8;
             font-size: 1.1rem;
         }
@@ -417,6 +426,9 @@
         }
 
         .sf-user-name {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             margin: 0 0 5px;
             font-family: var(--font-heading);
             font-size: 1.4rem;
@@ -473,6 +485,9 @@
         }
 
         .sf-user-reason {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-size: 1.05rem;
             color: var(--text-main);
             line-height: 1.6;
@@ -537,6 +552,9 @@
         }
 
         .sf-quote-content {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-family: var(--font-heading);
             font-size: 1.5rem;
             color: var(--text-main);
@@ -552,6 +570,9 @@
         }
 
         .sf-quote-reason {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             font-size: 0.9rem;
             color: #888;
             border-top: 1px solid #eee;
@@ -561,6 +582,9 @@
 
         /* Footer */
         footer {
+            word-wrap: break-word;
+            word-break: break-all;
+            overflow: hidden;
             margin-top: 60px;
             text-align: center;
             color: var(--red-festive);

--- a/src/infrastructure/reporting/templates/spring_festival/quote_item.html
+++ b/src/infrastructure/reporting/templates/spring_festival/quote_item.html
@@ -16,7 +16,7 @@
         <div class="sf-quote-bubble">
             <div class="sf-quote-content">“{{ quote.content }}”</div>
             <div class="sf-quote-author">—— {{ quote.sender }}</div>
-            <div class="sf-quote-reason">【评语】{{ quote.reason }}</div>
+            <div class="sf-quote-reason">【评语】{{ quote.reason | safe }}</div>
         </div>
     </div>
     {% endfor %}


### PR DESCRIPTION
## 🎯 目标
修复图像渲染时包含 HTML 与 Base64 乱码，以及相关联的 JSON 解析失败问题。

## 🐛 1. 问题背景与表象
在群聊分析结果生成的图片中，经常在“群圣经（金句）”或部分文本内容的理由分析 (`quote.reason` / `topic.detail`) 区域出现一长串乱码。
* 渲染出大段类似 `<span class="user-capsule" style="...">...</span>` 的纯文本代码，暴露出极长的 Base64 图片数据。
* 伴随由于代码超长导致的图片被撑大至 10,000+ 像素宽，引发渲染超时 (错误码 -917) 或排版错乱。
* 终端日志偶发报出 JSON 解析失败 (`Expecting ':' delimiter...`) 或截断问题。

## 🔍 2. 根本原因深度分析
经过源码分析，问题由输入污染与输出渲染转义两个维度的 Bug 共同导致：

* **维度 A：大模型输入数据污染（导致 JSON 解析失败）**
  发送给 LLM 的群聊记录中混入了原始 HTML 标签、Base64 内联图片代码及非法控制字符。LLM 被这些冗余数据“污染”后，极易生成残缺或语法错误的 JSON，导致底层 JSON 解析器报错。
* **维度 B：渲染阶段 Jinja2 HTML 转义（导致输出乱码）**
  `generators.py` 组装生成 HTML 时，主动将如 `[123456]` 替换成了带有头像的 HTML 胶囊气泡代码。但在 6 个主题模板的 `quote_item.html` 和 `topic_item.html` 中，Jinja2 模板渲染时遗漏了 `| safe` 过滤器。导致 Jinja2 出于 XSS 防护，将注入的 HTML 标签直接转义为纯文本，最终在图片上裸露出了长达几千个字符的 Base64 头像数据。

## 🛠️ 3. 解决方案
* **步骤 1：拦截输入污染** - 在 `message_cleaner_service.py` 新增 `sanitize_chat_text` 方法，在发送给大模型前剔除 HTML 标签、Base64 和控制字符。
* **步骤 2：优化 JSON 解析健壮性** - 在 `json_utils.py` 实现括号平衡提取算法 `_extract_json_balanced`，解决非贪婪正则在遇到字符串内包含 `]` 时提前截断 JSON 的致命问题。
* **步骤 3：修复 Jinja2 模板 XSS 转义** - 将所有主题模板中输出用户评价内容的变量添加 `| safe` 过滤器 (如 `{{ quote.reason | safe }}`)。
* **步骤 4：增强 CSS 换行防御** - 在各个主题的 `image_template.html` 全局添加 `word-break: break-all;` 防御性策略，防止极端超长字符撑爆图片。

## 📁 4. 受影响的文件清单
* `src/domain/services/message_cleaner_service.py`
* `src/infrastructure/analysis/utils/json_utils.py`
* `src/infrastructure/analysis/analyzers/` (包含 topic, chat_quality, golden_quote, user_title_analyzer 等)
* `src/infrastructure/reporting/templates/*/quote_item.html` (6 款主题)
* `src/infrastructure/reporting/templates/*/image_template.html` (6 款主题)

## Summary by Sourcery

Improve robustness of JSON parsing and chat analysis prompts while hardening image report rendering against malformed or excessively long content.

Bug Fixes:
- Sanitize chat text before building LLM prompts to strip HTML tags, Base64 data URIs, control characters and normalize quotes, preventing polluted inputs from breaking JSON responses and HTML layout.
- Replace naive regex-based JSON extraction with a balanced bracket parser for arrays and objects, reducing JSON parse failures when content includes embedded bracket characters.
- Adjust group analysis interaction to always use reaction emojis instead of optional text replies, avoiding configuration-related inconsistencies.

Enhancements:
- Strengthen JSON fix-up logic by simplifying Unicode punctuation normalization and improving handling of truncated and malformed structures.
- Apply global word wrapping and overflow protection styles across all image report themes to prevent extremely long text from stretching rendered images.
- Mark quote reason fields in all report templates as safe HTML to allow intended rich formatting output from the analysis results while preserving layout.