### PR TITLE
fix(scheduler): schedule_jobs 后重置 _terminating 标志位，修复分析任务静默跳过

### DIFF
--- a/src/infrastructure/scheduler/auto_scheduler.py
+++ b/src/infrastructure/scheduler/auto_scheduler.py
@@ -149,6 +149,10 @@ class AutoScheduler:
         # 先清理旧任务
         self.unschedule_jobs(context)
 
+        # unschedule_jobs 会将 _terminating 置为 True（用于关闭场景），
+        # 但 schedule_jobs 表示插件仍在运行，需要重置终止标志位
+        self._terminating = False
+
         if not self.config_manager.get_enable_auto_analysis():
             logger.info("自动分析功能未启用，不注册定时任务")
             return


### PR DESCRIPTION
### 背景与目标

v4.9.6 引入了 `_terminating` 生命周期标志位，用于在插件卸载/重载时阻止异步任务继续执行。
但 [schedule_jobs()](cci:1://file:///d:/ONE/CODE/AstrBot/data/plugins/astrbot_plugin_qq_group_daily_analysis/src/infrastructure/scheduler/auto_scheduler.py:146:4-167:54) 在注册新任务前会调用 [unschedule_jobs()](cci:1://file:///d:/ONE/CODE/AstrBot/data/plugins/astrbot_plugin_qq_group_daily_analysis/src/infrastructure/scheduler/auto_scheduler.py:274:4-295:38) 清理旧任务，而 [unschedule_jobs()](cci:1://file:///d:/ONE/CODE/AstrBot/data/plugins/astrbot_plugin_qq_group_daily_analysis/src/infrastructure/scheduler/auto_scheduler.py:274:4-295:38) 会将 `_terminating` 置为 `True`。
注册完新任务后该标志位未被重置，导致后续所有分析任务（包括定时触发和手动触发）在入口处检测到 `_terminating == True` 后静默返回，不执行任何分析逻辑，也不产生任何日志输出。

### 变更漫游

| 文件 | 变更要点 | 增删 |
|------|---------|------|
| [src/infrastructure/scheduler/auto_scheduler.py](cci:7://file:///d:/ONE/CODE/AstrBot/data/plugins/astrbot_plugin_qq_group_daily_analysis/src/infrastructure/scheduler/auto_scheduler.py:0:0-0:0) | [schedule_jobs()](cci:1://file:///d:/ONE/CODE/AstrBot/data/plugins/astrbot_plugin_qq_group_daily_analysis/src/infrastructure/scheduler/auto_scheduler.py:146:4-167:54) 中调用 [unschedule_jobs()](cci:1://file:///d:/ONE/CODE/AstrBot/data/plugins/astrbot_plugin_qq_group_daily_analysis/src/infrastructure/scheduler/auto_scheduler.py:274:4-295:38) 之后重置 `_terminating = False` | +4 |

### 行为变化

| 场景 | 变更前 | 变更后 |
|------|--------|--------|
| 插件初始化后定时任务触发 | `_terminating=True`，[_run_auto_analysis](cci:1://file:///d:/ONE/CODE/AstrBot/data/plugins/astrbot_plugin_qq_group_daily_analysis/src/infrastructure/scheduler/auto_scheduler.py:349:4-407:73) 静默返回，无日志无报告 | `_terminating=False`，正常执行分析并分发报告 |
| 插件重载后手动触发分析 | 同上 | 同上 |
| 插件卸载/关闭 | [unschedule_jobs](cci:1://file:///d:/ONE/CODE/AstrBot/data/plugins/astrbot_plugin_qq_group_daily_analysis/src/infrastructure/scheduler/auto_scheduler.py:274:4-295:38) 设置 `_terminating=True`，任务正常终止 | 行为不变 |

### 验证建议

- [ ] 启动插件后检查定时分析任务是否在配置时间点正常执行（观察日志中是否出现 `开始执行自动群聊分析` ）
- [ ] 手动触发 `/群分析` 确认不再静默跳过
- [ ] 插件重载后再次验证上述场景

## Summary by Sourcery

Bug Fixes:
- Prevent analysis jobs from being silently skipped by clearing the terminating flag after unscheduling and before registering new tasks.