### PR TITLE
增加了html_only_url选项，使在选择输出格式为html时可以单独发送BaseURL

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -372,6 +372,12 @@
                 "default": "",
                 "hint": "HTML报告文件的保存目录，用于存储生成的 HTML 文件和原始 JSON 数据。留空则自动使用插件数据目录（astrbot_path/data/plugin_data/astrbot_plugin_qq_group_daily_analysis/）下的 self_hosted_html_reports 目录。"
             },
+            "html_only_url": {
+                "type": "bool",
+                "description": "仅发送外链",
+                "default": false,
+                "hint": "勾选后，若配置了外链 Base URL，则发送 HTML 报告时将只发送外链链接，不再发送HTML文件，若未勾选，将保持发送HTML文件。"
+            },
             "html_filename_format": {
                 "type": "string",
                 "description": "HTML文件名格式",

--- a/main.py
+++ b/main.py
@@ -635,10 +635,15 @@ class GroupDailyAnalysis(Star):
                     if base_url and base_url.strip():
                         filename = os.path.basename(html_path)
                         report_url = f"{base_url.rstrip('/')}/{filename}"
-                        yield event.plain_result(f"📊 今日群聊分析报告已生成：\n{report_url}")
+                        yield event.plain_result(
+                            f"📊 今日群聊分析报告已生成：\n{report_url}"
+                        )
                         return  # 拦截成功，直接退出，不再发文件
                     else:
-                        logger.warning(f"手动触发群 {group_id} 开启了仅发送外链，但未配置 html_base_url，回退至发送文件。")
+                        logger.warning(
+                            f"手动触发群 {group_id} 开启了仅发送外链，但未配置 html_base_url，回退至发送文件。"
+                        )
+
                 caption = self.report_generator.build_html_caption(html_path)
 
                 # 发送 HTML 文件

--- a/main.py
+++ b/main.py
@@ -628,6 +628,17 @@ class GroupDailyAnalysis(Star):
                 nickname_getter=nickname_getter,
             )
             if html_path:
+                is_only_url = self.config_manager.get_html_only_url()
+                base_url = self.config_manager.get_html_base_url()
+
+                if is_only_url:
+                    if base_url and base_url.strip():
+                        filename = os.path.basename(html_path)
+                        report_url = f"{base_url.rstrip('/')}/{filename}"
+                        yield event.plain_result(f"📊 今日群聊分析报告已生成：\n{report_url}")
+                        return  # 拦截成功，直接退出，不再发文件
+                    else:
+                        logger.warning(f"手动触发群 {group_id} 开启了仅发送外链，但未配置 html_base_url，回退至发送文件。")
                 caption = self.report_generator.build_html_caption(html_path)
 
                 # 发送 HTML 文件

--- a/src/infrastructure/config/config_manager.py
+++ b/src/infrastructure/config/config_manager.py
@@ -266,6 +266,15 @@ class ConfigManager:
         """获取HTML外链Base URL"""
         return self._get_group("html").get("html_base_url", "")
 
+    def get_html_only_url(self) -> bool:
+        """获取是否仅输出外链而不发送文件本体"""
+        return self._get_group("html").get("html_only_url", False)
+
+    def set_html_only_url(self, enabled: bool):
+        """设置是否仅输出外链而不发送文件本体"""
+        self._ensure_group("html")["html_only_url"] = enabled
+        self.config.save_config()
+
     def get_html_filename_format(self) -> str:
         """获取HTML文件名格式"""
         return self._get_group("html").get(

--- a/src/infrastructure/reporting/dispatcher.py
+++ b/src/infrastructure/reporting/dispatcher.py
@@ -125,6 +125,26 @@ class ReportDispatcher:
             logger.error(f"[{trace_id}] Failed to generate HTML report: {e}")
 
         if html_path:
+            is_only_url = self.config_manager.get_html_only_url()
+            base_url = self.config_manager.get_html_base_url()
+
+            if is_only_url:
+                if base_url and base_url.strip():
+                    filename = os.path.basename(html_path)
+                    report_url = f"{base_url.rstrip('/')}/{filename}"
+                    
+                    sent = await self.message_sender.send_text(
+                        group_id, 
+                        f"📊 今日群聊分析报告已生成：\n{report_url}", 
+                        platform_id
+                    )
+                    if sent:
+                        return True
+                else:
+                    logger.warning(
+                        f"[{trace_id}] 群 {group_id} 开启了仅发送外链，但未配置 html_base_url，已进行降级，回退至发送 HTML 文件。"
+                    )
+
             caption = self.report_generator.build_html_caption(html_path)
 
             sent = await self.message_sender.send_file(

--- a/src/infrastructure/reporting/dispatcher.py
+++ b/src/infrastructure/reporting/dispatcher.py
@@ -133,12 +133,13 @@ class ReportDispatcher:
                 if base_url and base_url.strip():
                     filename = os.path.basename(html_path)
                     report_url = f"{base_url.rstrip('/')}/{filename}"
-                    
+
                     sent = await self.message_sender.send_text(
-                        group_id, 
-                        f"📊 今日群聊分析报告已生成：\n{report_url}", 
-                        platform_id
+                        group_id,
+                        f"📊 今日群聊分析报告已生成：\n{report_url}",
+                        platform_id,
                     )
+
                     if sent:
                         return True
                 else:

--- a/src/infrastructure/reporting/dispatcher.py
+++ b/src/infrastructure/reporting/dispatcher.py
@@ -116,6 +116,8 @@ class ReportDispatcher:
     ) -> bool:
         trace_id = TraceContext.get()
 
+        logger.warn(''逻辑判断被加载'')
+
         html_path = None
         try:
             html_path, json_path = await self.report_generator.generate_html_report(

--- a/src/infrastructure/reporting/dispatcher.py
+++ b/src/infrastructure/reporting/dispatcher.py
@@ -116,7 +116,7 @@ class ReportDispatcher:
     ) -> bool:
         trace_id = TraceContext.get()
 
-        logger.warn(''逻辑判断被加载'')
+        logger.warn("逻辑判断被加载")
 
         html_path = None
         try:

--- a/src/infrastructure/reporting/dispatcher.py
+++ b/src/infrastructure/reporting/dispatcher.py
@@ -41,6 +41,7 @@ class ReportDispatcher:
         """
         trace_id = TraceContext.get()
         output_format = self.config_manager.get_output_format()
+
         logger.info(
             f"[{trace_id}] 正在分发群 {group_id} 的报告 (格式: {output_format})"
         )
@@ -115,8 +116,6 @@ class ReportDispatcher:
         self, group_id: str, analysis_result: dict[str, Any], platform_id: str | None
     ) -> bool:
         trace_id = TraceContext.get()
-
-        logger.warn("逻辑判断被加载")
 
         html_path = None
         try:


### PR DESCRIPTION
修改了html文件的输出，新增了`html_only_url`选项，在`main.py`和`dispatcher.py`中新增了判断，当`html_only_url`处于打开状态时，将只输出Base URL而不输出html文件

This PR fixes​ #163

## Summary by Sourcery

Add support for sending only the HTML report URL instead of the HTML file when HTML output is selected.

New Features:
- Introduce a configurable html_only_url option to control whether only an external HTML report link is sent instead of the HTML file.
- Enable HTML report dispatchers and manual triggers to send a report URL built from html_base_url and the generated filename when html_only_url is enabled.

Enhancements:
- Extend configuration management and schema to store and persist the html_only_url flag for HTML reporting behavior.