### PR TITLE
fix:修复了当html_only_url打开时，URL拼接错误问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -633,8 +633,24 @@ class GroupDailyAnalysis(Star):
 
                 if is_only_url:
                     if base_url and base_url.strip():
-                        filename = os.path.basename(html_path)
-                        report_url = f"{base_url.rstrip('/')}/{filename}"
+
+                        # 获取配置中的输出目录
+                        html_output_dir = self.config_manager.get_html_output_dir()
+                    
+                        # 若用户配置为空，使用默认目录
+                        if not html_output_dir:
+                            try:
+                                from astrbot.api.star import StarTools
+                                html_output_dir = os.path.join(StarTools.get_data_dir(), "self_hosted_html_reports")
+                            except Exception:
+                                from astrbot.core.utils.astrbot_path import get_astrbot_data_path
+                                html_output_dir = os.path.join(get_astrbot_data_path(), "plugin_data", "astrbot_plugin_qq_group_daily_analysis", "self_hosted_html_reports")
+                    
+                        # 计算相对路径并转换为URL
+                        rel_path = os.path.relpath(html_path, html_output_dir)
+                        url_path = rel_path.replace(os.sep, '/')
+                        report_url = f"{base_url.rstrip('/')}/{url_path.lstrip('/')}"
+
                         yield event.plain_result(
                             f"📊 今日群聊分析报告已生成：\n{report_url}"
                         )

--- a/main.py
+++ b/main.py
@@ -633,22 +633,32 @@ class GroupDailyAnalysis(Star):
 
                 if is_only_url:
                     if base_url and base_url.strip():
-
                         # 获取配置中的输出目录
                         html_output_dir = self.config_manager.get_html_output_dir()
-                    
+
                         # 若用户配置为空，使用默认目录
                         if not html_output_dir:
                             try:
                                 from astrbot.api.star import StarTools
-                                html_output_dir = os.path.join(StarTools.get_data_dir(), "self_hosted_html_reports")
+
+                                html_output_dir = os.path.join(
+                                    StarTools.get_data_dir(), "self_hosted_html_reports"
+                                )
                             except Exception:
-                                from astrbot.core.utils.astrbot_path import get_astrbot_data_path
-                                html_output_dir = os.path.join(get_astrbot_data_path(), "plugin_data", "astrbot_plugin_qq_group_daily_analysis", "self_hosted_html_reports")
-                    
+                                from astrbot.core.utils.astrbot_path import (
+                                    get_astrbot_data_path,
+                                )
+
+                                html_output_dir = os.path.join(
+                                    get_astrbot_data_path(),
+                                    "plugin_data",
+                                    "astrbot_plugin_qq_group_daily_analysis",
+                                    "self_hosted_html_reports",
+                                )
+
                         # 计算相对路径并转换为URL
                         rel_path = os.path.relpath(html_path, html_output_dir)
-                        url_path = rel_path.replace(os.sep, '/')
+                        url_path = rel_path.replace(os.sep, "/")
                         report_url = f"{base_url.rstrip('/')}/{url_path.lstrip('/')}"
 
                         yield event.plain_result(

--- a/src/infrastructure/reporting/dispatcher.py
+++ b/src/infrastructure/reporting/dispatcher.py
@@ -131,22 +131,32 @@ class ReportDispatcher:
 
             if is_only_url:
                 if base_url and base_url.strip():
-
                     # 获取配置的目录
                     html_output_dir = self.config_manager.get_html_output_dir()
-                    
+
                     # 若用户配置为空，使用默认目录
                     if not html_output_dir:
                         try:
                             from astrbot.api.star import StarTools
-                            html_output_dir = os.path.join(StarTools.get_data_dir(), "self_hosted_html_reports")
+
+                            html_output_dir = os.path.join(
+                                StarTools.get_data_dir(), "self_hosted_html_reports"
+                            )
                         except Exception:
-                            from astrbot.core.utils.astrbot_path import get_astrbot_data_path
-                            html_output_dir = os.path.join(get_astrbot_data_path(), "plugin_data", "astrbot_plugin_qq_group_daily_analysis", "self_hosted_html_reports")
-                    
+                            from astrbot.core.utils.astrbot_path import (
+                                get_astrbot_data_path,
+                            )
+
+                            html_output_dir = os.path.join(
+                                get_astrbot_data_path(),
+                                "plugin_data",
+                                "astrbot_plugin_qq_group_daily_analysis",
+                                "self_hosted_html_reports",
+                            )
+
                     # 计算相对路径并转换为URL
                     rel_path = os.path.relpath(html_path, html_output_dir)
-                    url_path = rel_path.replace(os.sep, '/')
+                    url_path = rel_path.replace(os.sep, "/")
                     report_url = f"{base_url.rstrip('/')}/{url_path.lstrip('/')}"
 
                     sent = await self.message_sender.send_text(

--- a/src/infrastructure/reporting/dispatcher.py
+++ b/src/infrastructure/reporting/dispatcher.py
@@ -131,8 +131,23 @@ class ReportDispatcher:
 
             if is_only_url:
                 if base_url and base_url.strip():
-                    filename = os.path.basename(html_path)
-                    report_url = f"{base_url.rstrip('/')}/{filename}"
+
+                    # 获取配置的目录
+                    html_output_dir = self.config_manager.get_html_output_dir()
+                    
+                    # 若用户配置为空，使用默认目录
+                    if not html_output_dir:
+                        try:
+                            from astrbot.api.star import StarTools
+                            html_output_dir = os.path.join(StarTools.get_data_dir(), "self_hosted_html_reports")
+                        except Exception:
+                            from astrbot.core.utils.astrbot_path import get_astrbot_data_path
+                            html_output_dir = os.path.join(get_astrbot_data_path(), "plugin_data", "astrbot_plugin_qq_group_daily_analysis", "self_hosted_html_reports")
+                    
+                    # 计算相对路径并转换为URL
+                    rel_path = os.path.relpath(html_path, html_output_dir)
+                    url_path = rel_path.replace(os.sep, '/')
+                    report_url = f"{base_url.rstrip('/')}/{url_path.lstrip('/')}"
 
                     sent = await self.message_sender.send_text(
                         group_id,


### PR DESCRIPTION
This PR fixes​ #168 
修改了`dispatcher.py`和`main.py`中当html_only_url打开时关于URL拼接的部分代码

## Summary by Sourcery

Bug Fixes:
- Correct HTML report URL assembly when only-URL mode is enabled by building URLs from the report path relative to the configured or default HTML output directory.