### PR TITLE
feat: 支持可选的流式 LLM 调用

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -337,6 +337,12 @@
                 "description": "LLM 请求重试退避基值（秒）",
                 "default": 2,
                 "hint": "重试之间的基准等待时间（秒），实际等待时间为基值乘以尝试次数。"
+            },
+            "enable_streaming_llm_call": {
+                "type": "bool",
+                "description": "启用流式 LLM 调用",
+                "default": false,
+                "hint": "默认关闭，使用原有非流式调用方式。开启后，插件将使用 AstrBot Provider 的流式接口并聚合结果，适用于仅支持 stream=true 的服务。"
             }
         }
     },

--- a/src/infrastructure/analysis/utils/llm_utils.py
+++ b/src/infrastructure/analysis/utils/llm_utils.py
@@ -4,6 +4,7 @@ LLM API请求处理工具模块
 """
 
 import asyncio
+from types import SimpleNamespace
 
 from ....utils.logger import logger
 from ....utils.resilience import CircuitBreaker, GlobalRateLimiter
@@ -34,6 +35,39 @@ def _get_circuit_breaker(provider_id: str) -> CircuitBreaker:
     if provider_id not in _circuit_breakers:
         _circuit_breakers[provider_id] = CircuitBreaker(name=f"provider_{provider_id}")
     return _circuit_breakers[provider_id]
+
+
+async def _call_provider_stream(
+    context, provider_id: str, llm_kwargs: dict[str, object]
+):
+    provider = context.get_provider_by_id(provider_id=provider_id)
+    if provider is None:
+        raise RuntimeError(f"Provider 不存在: {provider_id}")
+
+    stream_kwargs = dict(llm_kwargs)
+    stream_kwargs.pop("chat_provider_id", None)
+
+    final_resp = None
+    content_parts: list[str] = []
+    async for resp in provider.text_chat_stream(**stream_kwargs):
+        final_resp = resp
+        if getattr(resp, "is_chunk", False):
+            text = getattr(resp, "completion_text", "")
+            if text:
+                content_parts.append(text)
+
+    if final_resp is None:
+        raise RuntimeError("流式 LLM 调用未返回任何响应")
+
+    final_text = extract_response_text(final_resp)
+    if final_text and not getattr(final_resp, "is_chunk", False):
+        return final_resp
+
+    return SimpleNamespace(
+        completion_text="".join(content_parts),
+        usage=getattr(final_resp, "usage", None),
+        raw_completion=getattr(final_resp, "raw_completion", None),
+    )
 
 
 async def _try_get_provider_id_by_id(
@@ -285,10 +319,21 @@ async def call_provider_with_retry(
                     if extra_generate_kwargs:
                         llm_kwargs.update(extra_generate_kwargs)
 
+                    enable_streaming_llm_call = (
+                        config_manager.get_enable_streaming_llm_call()
+                    )
+                    if enable_streaming_llm_call:
+                        logger.info("[LLM 调用] 使用流式 Provider 调用")
+
                     try:
-                        llm_resp = await context.llm_generate(
-                            **llm_kwargs,
-                        )
+                        if enable_streaming_llm_call:
+                            llm_resp = await _call_provider_stream(
+                                context, provider_id, llm_kwargs
+                            )
+                        else:
+                            llm_resp = await context.llm_generate(
+                                **llm_kwargs,
+                            )
                     except Exception as e:
                         if (
                             response_format is not None
@@ -299,9 +344,14 @@ async def call_provider_with_retry(
                                 "已自动降级为无 schema 约束重试本次请求。"
                             )
                             llm_kwargs.pop("response_format", None)
-                            llm_resp = await context.llm_generate(
-                                **llm_kwargs,
-                            )
+                            if enable_streaming_llm_call:
+                                llm_resp = await _call_provider_stream(
+                                    context, provider_id, llm_kwargs
+                                )
+                            else:
+                                llm_resp = await context.llm_generate(
+                                    **llm_kwargs,
+                                )
                         else:
                             raise
 

--- a/src/infrastructure/analysis/utils/llm_utils.py
+++ b/src/infrastructure/analysis/utils/llm_utils.py
@@ -4,7 +4,8 @@ LLM API请求处理工具模块
 """
 
 import asyncio
-from types import SimpleNamespace
+
+from astrbot.api.provider import LLMResponse
 
 from ....utils.logger import logger
 from ....utils.resilience import CircuitBreaker, GlobalRateLimiter
@@ -63,7 +64,8 @@ async def _call_provider_stream(
     if final_text and not getattr(final_resp, "is_chunk", False):
         return final_resp
 
-    return SimpleNamespace(
+    return LLMResponse(
+        role="assistant",
         completion_text="".join(content_parts),
         usage=getattr(final_resp, "usage", None),
         raw_completion=getattr(final_resp, "raw_completion", None),
@@ -263,6 +265,9 @@ async def call_provider_with_retry(
     retries = config_manager.get_llm_retries()
     backoff = config_manager.get_llm_backoff()
 
+    # 检查流式调用配置
+    enable_streaming_llm_call = config_manager.get_enable_streaming_llm_call()
+
     last_exc = None
     for attempt in range(1, retries + 1):
         try:
@@ -319,21 +324,16 @@ async def call_provider_with_retry(
                     if extra_generate_kwargs:
                         llm_kwargs.update(extra_generate_kwargs)
 
-                    enable_streaming_llm_call = (
-                        config_manager.get_enable_streaming_llm_call()
-                    )
                     if enable_streaming_llm_call:
                         logger.info("[LLM 调用] 使用流式 Provider 调用")
 
-                    try:
+                    async def _invoke_llm(pid: str):
                         if enable_streaming_llm_call:
-                            llm_resp = await _call_provider_stream(
-                                context, provider_id, llm_kwargs
-                            )
-                        else:
-                            llm_resp = await context.llm_generate(
-                                **llm_kwargs,
-                            )
+                            return await _call_provider_stream(context, pid, llm_kwargs)
+                        return await context.llm_generate(**llm_kwargs)
+
+                    try:
+                        llm_resp = await _invoke_llm(provider_id)
                     except Exception as e:
                         if (
                             response_format is not None
@@ -344,14 +344,7 @@ async def call_provider_with_retry(
                                 "已自动降级为无 schema 约束重试本次请求。"
                             )
                             llm_kwargs.pop("response_format", None)
-                            if enable_streaming_llm_call:
-                                llm_resp = await _call_provider_stream(
-                                    context, provider_id, llm_kwargs
-                                )
-                            else:
-                                llm_resp = await context.llm_generate(
-                                    **llm_kwargs,
-                                )
+                            llm_resp = await _invoke_llm(provider_id)
                         else:
                             raise
 

--- a/src/infrastructure/config/config_manager.py
+++ b/src/infrastructure/config/config_manager.py
@@ -194,6 +194,10 @@ class ConfigManager:
         """获取LLM请求重试退避基值（秒），实际退避会乘以尝试次数"""
         return self._get_group("llm").get("llm_backoff", 2)
 
+    def get_enable_streaming_llm_call(self) -> bool:
+        """获取是否启用流式 LLM 调用"""
+        return self._get_group("llm").get("enable_streaming_llm_call", False)
+
     def get_debug_mode(self) -> bool:
         """获取是否启用调试模式"""
         return self._get_group("basic").get("debug_mode", False)


### PR DESCRIPTION
## 改动说明

新增一个默认关闭的配置项 `enable_streaming_llm_call`，用于让插件在 LLM 分析时通过 AstrBot Provider 的 `text_chat_stream()` 进行流式调用，并聚合结果后复用现有解析逻辑。

默认关闭时仍使用原有的 `context.llm_generate()`，不影响现有用户。

## 背景

部分 OpenAI Compatible Provider 只接受 `stream=true` 请求，非流式调用会失败。该选项用于兼容这类 Provider。

## 测试

已使用只支持流式调用的 OpenAI Compatible Provider 测试，话题、用户称号、金句、聊天质量分析和图片报告生成均正常完成。

## Summary by Sourcery

Add an optional streaming LLM invocation path controlled by configuration to support providers requiring streamed requests while preserving existing behavior by default.

Enhancements:
- Introduce a configuration flag to enable streaming LLM calls via provider text_chat_stream while reusing existing parsing logic.
- Route LLM calls through either the new streaming helper or the existing llm_generate path based on the streaming flag, including retry downgrade handling.
- Extend the configuration manager with an accessor for the new streaming LLM option.