### PR TITLE
fix: pass plugin name to StarTools.get_data_dir() to avoid inspect.stack() crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,15 +88,7 @@ class GroupDailyAnalysis(Star):
         self.bot_manager.set_plugin_instance(self)
         self.history_manager = HistoryManager(self)
 
-        try:
-            plugin_data_dir = StarTools.get_data_dir()
-        except Exception:
-            # 回退逻辑：手动构造满足规范的路径
-            plugin_data_dir = (
-                Path(get_astrbot_data_path())
-                / "plugin_data"
-                / "astrbot_plugin_qq_group_daily_analysis"
-            )
+        plugin_data_dir = StarTools.get_data_dir("astrbot_plugin_qq_group_daily_analysis")
 
         self.report_generator = ReportGenerator(self.config_manager, plugin_data_dir)
 
@@ -640,23 +632,11 @@ class GroupDailyAnalysis(Star):
 
                         # 若用户配置为空，使用默认目录
                         if not html_output_dir:
-                            try:
-                                from astrbot.api.star import StarTools
+                            from astrbot.api.star import StarTools
 
-                                html_output_dir = os.path.join(
-                                    StarTools.get_data_dir(), "self_hosted_html_reports"
-                                )
-                            except Exception:
-                                from astrbot.core.utils.astrbot_path import (
-                                    get_astrbot_data_path,
-                                )
-
-                                html_output_dir = os.path.join(
-                                    get_astrbot_data_path(),
-                                    "plugin_data",
-                                    "astrbot_plugin_qq_group_daily_analysis",
-                                    "self_hosted_html_reports",
-                                )
+                            html_output_dir = os.path.join(
+                                StarTools.get_data_dir("astrbot_plugin_qq_group_daily_analysis"), "self_hosted_html_reports"
+                            )
 
                         # 计算相对路径并转换为URL
                         rel_path = os.path.relpath(html_path, html_output_dir)

--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ from .src.infrastructure.platform.template_preview import (
 )
 from .src.infrastructure.reporting.generators import ReportGenerator
 from .src.infrastructure.scheduler.auto_scheduler import AutoScheduler
+from .src.shared.constants import PLUGIN_NAME
 from .src.shared.trace_context import TraceContext, TraceLogFilter
 from .src.utils.logger import logger
 from .src.utils.resilience import GlobalRateLimiter
@@ -77,10 +78,6 @@ class GroupDailyAnalysis(Star):
         super().__init__(context)
         self.config = config
 
-        from pathlib import Path
-
-        from astrbot.core.utils.astrbot_path import get_astrbot_data_path
-
         # 1. 基础设施层
         self.config_manager = ConfigManager(config)
         self.bot_manager = BotManager(self.config_manager)
@@ -88,7 +85,7 @@ class GroupDailyAnalysis(Star):
         self.bot_manager.set_plugin_instance(self)
         self.history_manager = HistoryManager(self)
 
-        plugin_data_dir = StarTools.get_data_dir("astrbot_plugin_qq_group_daily_analysis")
+        plugin_data_dir = StarTools.get_data_dir(PLUGIN_NAME)
 
         self.report_generator = ReportGenerator(self.config_manager, plugin_data_dir)
 
@@ -635,7 +632,8 @@ class GroupDailyAnalysis(Star):
                             from astrbot.api.star import StarTools
 
                             html_output_dir = os.path.join(
-                                StarTools.get_data_dir("astrbot_plugin_qq_group_daily_analysis"), "self_hosted_html_reports"
+                                StarTools.get_data_dir(PLUGIN_NAME),
+                                "self_hosted_html_reports",
                             )
 
                         # 计算相对路径并转换为URL

--- a/src/infrastructure/analysis/analyzers/base_analyzer.py
+++ b/src/infrastructure/analysis/analyzers/base_analyzer.py
@@ -8,6 +8,7 @@ from collections.abc import Sized
 from typing import Generic, TypeVar
 
 from ....domain.models.data_models import TokenUsage
+from ....shared.constants import PLUGIN_NAME
 from ....utils.logger import logger
 from ..utils.json_utils import parse_json_response
 from ..utils.llm_utils import (
@@ -280,12 +281,9 @@ class BaseAnalyzer(ABC, Generic[TDataObject, TInputData]):
             session_id: 会话ID
         """
         try:
-            from pathlib import Path
-
             from astrbot.api.star import StarTools
-            from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 
-            data_path = StarTools.get_data_dir("astrbot_plugin_qq_group_daily_analysis") / "debug_data"
+            data_path = StarTools.get_data_dir(PLUGIN_NAME) / "debug_data"
 
             data_path.mkdir(parents=True, exist_ok=True)
 

--- a/src/infrastructure/analysis/analyzers/base_analyzer.py
+++ b/src/infrastructure/analysis/analyzers/base_analyzer.py
@@ -285,15 +285,7 @@ class BaseAnalyzer(ABC, Generic[TDataObject, TInputData]):
             from astrbot.api.star import StarTools
             from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 
-            try:
-                data_path = StarTools.get_data_dir() / "debug_data"
-            except Exception:
-                data_path = (
-                    Path(get_astrbot_data_path())
-                    / "plugin_data"
-                    / "astrbot_plugin_qq_group_daily_analysis"
-                    / "debug_data"
-                )
+            data_path = StarTools.get_data_dir("astrbot_plugin_qq_group_daily_analysis") / "debug_data"
 
             data_path.mkdir(parents=True, exist_ok=True)
 

--- a/src/infrastructure/analysis/llm_analyzer.py
+++ b/src/infrastructure/analysis/llm_analyzer.py
@@ -464,7 +464,7 @@ class LLMAnalyzer(IAnalysisProvider):
 
             from astrbot.api.star import StarTools
 
-            debug_dir = StarTools.get_data_dir() / "debug_data"
+            debug_dir = StarTools.get_data_dir("astrbot_plugin_qq_group_daily_analysis") / "debug_data"
             debug_dir.mkdir(parents=True, exist_ok=True)
 
             msg_file_path = debug_dir / f"{session_id}_messages.json"

--- a/src/infrastructure/analysis/llm_analyzer.py
+++ b/src/infrastructure/analysis/llm_analyzer.py
@@ -13,6 +13,7 @@ from ...domain.models.data_models import (
     UserTitle,
 )
 from ...domain.repositories.analysis_repository import IAnalysisProvider
+from ...shared.constants import PLUGIN_NAME
 from ...utils.logger import logger
 from .analyzers.chat_quality_analyzer import ChatQualityAnalyzer
 from .analyzers.golden_quote_analyzer import GoldenQuoteAnalyzer
@@ -464,7 +465,7 @@ class LLMAnalyzer(IAnalysisProvider):
 
             from astrbot.api.star import StarTools
 
-            debug_dir = StarTools.get_data_dir("astrbot_plugin_qq_group_daily_analysis") / "debug_data"
+            debug_dir = StarTools.get_data_dir(PLUGIN_NAME) / "debug_data"
             debug_dir.mkdir(parents=True, exist_ok=True)
 
             msg_file_path = debug_dir / f"{session_id}_messages.json"

--- a/src/infrastructure/config/config_manager.py
+++ b/src/infrastructure/config/config_manager.py
@@ -301,19 +301,9 @@ class ConfigManager:
 
         from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 
-        try:
-            default_path = StarTools.get_data_dir() / "self_hosted_html_reports"
-            val = self._get_group("html").get("html_output_dir")
-            return val if val else str(default_path)
-        except Exception:
-            val = self._get_group("html").get("html_output_dir")
-            fallback_path = (
-                Path(get_astrbot_data_path())
-                / "plugin_data"
-                / "astrbot_plugin_qq_group_daily_analysis"
-                / "self_hosted_html_reports"
-            )
-            return val if val else str(fallback_path)
+        default_path = StarTools.get_data_dir("astrbot_plugin_qq_group_daily_analysis") / "self_hosted_html_reports"
+        val = self._get_group("html").get("html_output_dir")
+        return val if val else str(default_path)
 
     def get_html_base_url(self) -> str:
         """获取HTML外链Base URL"""

--- a/src/infrastructure/config/config_manager.py
+++ b/src/infrastructure/config/config_manager.py
@@ -6,6 +6,7 @@
 from astrbot.api import AstrBotConfig
 from astrbot.api.star import StarTools
 
+from ...shared.constants import PLUGIN_NAME
 from ...utils.logger import logger
 from ..utils.template_utils import upgrade_str_format_template
 
@@ -297,11 +298,8 @@ class ConfigManager:
 
     def get_html_output_dir(self) -> str:
         """获取HTML输出目录"""
-        from pathlib import Path
 
-        from astrbot.core.utils.astrbot_path import get_astrbot_data_path
-
-        default_path = StarTools.get_data_dir("astrbot_plugin_qq_group_daily_analysis") / "self_hosted_html_reports"
+        default_path = StarTools.get_data_dir(PLUGIN_NAME) / "self_hosted_html_reports"
         val = self._get_group("html").get("html_output_dir")
         return val if val else str(default_path)
 

--- a/src/infrastructure/reporting/dispatcher.py
+++ b/src/infrastructure/reporting/dispatcher.py
@@ -149,23 +149,11 @@ class ReportDispatcher:
 
                     # 若用户配置为空，使用默认目录
                     if not html_output_dir:
-                        try:
-                            from astrbot.api.star import StarTools
+                        from astrbot.api.star import StarTools
 
-                            html_output_dir = os.path.join(
-                                StarTools.get_data_dir(), "self_hosted_html_reports"
-                            )
-                        except Exception:
-                            from astrbot.core.utils.astrbot_path import (
-                                get_astrbot_data_path,
-                            )
-
-                            html_output_dir = os.path.join(
-                                get_astrbot_data_path(),
-                                "plugin_data",
-                                "astrbot_plugin_qq_group_daily_analysis",
-                                "self_hosted_html_reports",
-                            )
+                        html_output_dir = os.path.join(
+                            StarTools.get_data_dir("astrbot_plugin_qq_group_daily_analysis"), "self_hosted_html_reports"
+                        )
 
                     # 计算相对路径并转换为URL
                     rel_path = os.path.relpath(html_path, html_output_dir)

--- a/src/infrastructure/reporting/dispatcher.py
+++ b/src/infrastructure/reporting/dispatcher.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 
+from ...shared.constants import PLUGIN_NAME
 from ...shared.trace_context import TraceContext
 from ...utils.logger import logger
 
@@ -152,7 +153,8 @@ class ReportDispatcher:
                         from astrbot.api.star import StarTools
 
                         html_output_dir = os.path.join(
-                            StarTools.get_data_dir("astrbot_plugin_qq_group_daily_analysis"), "self_hosted_html_reports"
+                            StarTools.get_data_dir(PLUGIN_NAME),
+                            "self_hosted_html_reports",
                         )
 
                     # 计算相对路径并转换为URL


### PR DESCRIPTION
### Problem
When `StarTools.get_data_dir()` is called without arguments, the framework attempts to deduce the calling plugin name using `inspect.stack()`. Under certain environments (such as dynamic reloading, testing shims, or direct scripts where `__main__` is the entrypoint), metadata extraction fails, throwing a fatal `RuntimeError: 无法获取模块 __main__ 的元信息`.

### Solution
Explicitly pass the plugin name `"astrbot_plugin_qq_group_daily_analysis"` to all calls of `StarTools.get_data_dir()` to avoid this dynamic inspection crash. This is safe, backwards-compatible, and robust across all execution environments.

Verified and tested successfully under AstrBot official environment.

## Summary by Sourcery

Ensure the plugin always uses a stable, explicit data directory for storage and HTML/debug outputs by passing the plugin name into StarTools.get_data_dir() instead of relying on runtime inspection and fallback paths.

Bug Fixes:
- Prevent crashes when resolving the plugin data directory by avoiding inspect-based plugin name deduction and always passing the plugin name explicitly.

Enhancements:
- Simplify and unify data, HTML report, and debug output directory resolution across the plugin by removing custom fallback path construction.

---

### 💡 Ecosystem & Framework Context
This issue stems from a known limitation in the AstrBot core framework's path-resolving API. We have submitted a core robustness fix to the official AstrBot core repository: **[AstrBot Core PR #8588](https://github.com/AstrBotDevs/AstrBot/pull/8588)**.

However, this plugin-level change (passing the plugin name explicitly) remains **highly necessary** to ensure backward compatibility. It prevents the plugin from crashing on older installations of AstrBot that have not upgraded to the latest core version.

This is a safe, non-breaking, and recommended change.
