### PR TITLE
feat(llm): 重构并优化模型请求的重试与降级补偿机制

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -336,7 +336,7 @@
                 "type": "int",
                 "description": "LLM 请求重试退避基值（秒）",
                 "default": 2,
-                "hint": "重试之间的基准等待时间（秒），实际等待时间为基值乘以尝试次数。"
+                "hint": "重试之间的基准等待时间（秒）。实际等待时间会随尝试次数指数增长，并加入少量随机抖动；当专用 Provider 失败后，会继续按队列尝试默认 Provider。"
             },
             "enable_streaming_llm_call": {
                 "type": "bool",

--- a/src/infrastructure/analysis/utils/llm_utils.py
+++ b/src/infrastructure/analysis/utils/llm_utils.py
@@ -5,13 +5,14 @@ LLM API请求处理工具模块
 
 import asyncio
 import random
-from typing import Any
 
 from astrbot.api.provider import LLMResponse
+from astrbot.api.star import Context
 
 from ....utils.logger import logger
 from ....utils.resilience import CircuitBreaker, GlobalRateLimiter
-from .structured_output_schema import JSONObject
+from ...config.config_manager import ConfigManager
+from .structured_output_schema import JSONObject, JSONValue
 
 _circuit_breakers = {}
 
@@ -40,7 +41,9 @@ def _get_circuit_breaker(provider_id: str) -> CircuitBreaker:
     return _circuit_breakers[provider_id]
 
 
-async def _call_provider_stream(context, provider_id: str, llm_kwargs: dict[str, Any]):
+async def _call_provider_stream(
+    context: Context, provider_id: str, llm_kwargs: dict[str, JSONValue]
+) -> LLMResponse:
     provider = context.get_provider_by_id(provider_id=provider_id)
     if provider is None:
         raise RuntimeError(f"Provider 不存在: {provider_id}")
@@ -151,8 +154,8 @@ async def _try_get_first_available_provider_id(context) -> str | None:
 
 
 async def get_provider_id_with_fallback(
-    context,
-    config_manager,
+    context: Context,
+    config_manager: ConfigManager,
     provider_id_key: str | None,
     umo: str | None = None,
 ) -> str | None:
@@ -235,15 +238,15 @@ async def get_provider_id_with_fallback(
 
 
 async def call_provider_with_retry(
-    context,
-    config_manager,
+    context: Context,
+    config_manager: ConfigManager,
     prompt: str,
     umo: str | None = None,
     provider_id_key: str | None = None,
     system_prompt: str | None = None,
     response_format: JSONObject | None = None,
-    extra_generate_kwargs: dict[str, Any] | None = None,
-) -> object | None:
+    extra_generate_kwargs: dict[str, JSONValue] | None = None,
+) -> LLMResponse | None:
     """
     调用LLM提供者，带超时、重试与退避。支持指定模型失效后自动降级到默认模型重试。
     """
@@ -274,7 +277,9 @@ async def call_provider_with_retry(
         return None
 
     # 2. 核心请求执行闭包
-    async def _execute_llm_request(pid: str, r_format: JSONObject | None):
+    async def _execute_llm_request(
+        pid: str, r_format: JSONObject | None
+    ) -> LLMResponse:
         cb = _get_circuit_breaker(pid)
         if not cb.allow_request():
             logger.warning(f"Provider {pid} 熔断器已打开，跳过本次请求")
@@ -282,7 +287,7 @@ async def call_provider_with_retry(
 
         try:
             async with GlobalRateLimiter.get_instance().semaphore:
-                llm_kwargs: dict[str, Any] = {
+                llm_kwargs: dict[str, JSONValue] = {
                     "chat_provider_id": pid,
                     "prompt": prompt,
                 }

--- a/src/infrastructure/analysis/utils/llm_utils.py
+++ b/src/infrastructure/analysis/utils/llm_utils.py
@@ -40,9 +40,7 @@ def _get_circuit_breaker(provider_id: str) -> CircuitBreaker:
     return _circuit_breakers[provider_id]
 
 
-async def _call_provider_stream(
-    context, provider_id: str, llm_kwargs: dict[str, Any]
-):
+async def _call_provider_stream(context, provider_id: str, llm_kwargs: dict[str, Any]):
     provider = context.get_provider_by_id(provider_id=provider_id)
     if provider is None:
         raise RuntimeError(f"Provider 不存在: {provider_id}")
@@ -315,7 +313,7 @@ async def call_provider_with_retry(
 
     for i, (current_pid, is_fallback) in enumerate(attempt_queue):
         attempt_num = i + 1
-        is_last_attempt = (i == len(attempt_queue) - 1)
+        is_last_attempt = i == len(attempt_queue) - 1
 
         # 修复状态污染：如果切换了全新的 Provider，必须重置 response_format 约束
         if current_pid != previous_pid:
@@ -339,12 +337,19 @@ async def call_provider_with_retry(
             last_exc = e
 
             # 处理不支持 response_format 的情况
-            if current_response_format is not None and _is_response_format_unsupported_error(e):
-                logger.warning(f"{prefix}当前 Provider 可能不支持 response_format，已自动降级为无 schema 约束。")
+            if (
+                current_response_format is not None
+                and _is_response_format_unsupported_error(e)
+            ):
+                logger.warning(
+                    f"{prefix}当前 Provider 可能不支持 response_format，已自动降级为无 schema 约束。"
+                )
                 current_response_format = None
                 # 在当前尝试额度内立即再试一次剥离了 schema 的请求
                 try:
-                    return await _execute_llm_request(current_pid, current_response_format)
+                    return await _execute_llm_request(
+                        current_pid, current_response_format
+                    )
                 except Exception as inner_e:
                     last_exc = inner_e
 

--- a/src/infrastructure/analysis/utils/llm_utils.py
+++ b/src/infrastructure/analysis/utils/llm_utils.py
@@ -4,6 +4,8 @@ LLM API请求处理工具模块
 """
 
 import asyncio
+import random
+from typing import Any
 
 from astrbot.api.provider import LLMResponse
 
@@ -39,7 +41,7 @@ def _get_circuit_breaker(provider_id: str) -> CircuitBreaker:
 
 
 async def _call_provider_stream(
-    context, provider_id: str, llm_kwargs: dict[str, object]
+    context, provider_id: str, llm_kwargs: dict[str, Any]
 ):
     provider = context.get_provider_by_id(provider_id=provider_id)
     if provider is None:
@@ -242,7 +244,7 @@ async def call_provider_with_retry(
     provider_id_key: str | None = None,
     system_prompt: str | None = None,
     response_format: JSONObject | None = None,
-    extra_generate_kwargs: dict[str, object] | None = None,
+    extra_generate_kwargs: dict[str, Any] | None = None,
 ) -> object | None:
     """
     调用LLM提供者，带超时、重试与退避。支持指定模型失效后自动降级到默认模型重试。
@@ -282,7 +284,7 @@ async def call_provider_with_retry(
 
         try:
             async with GlobalRateLimiter.get_instance().semaphore:
-                llm_kwargs: dict[str, object] = {
+                llm_kwargs: dict[str, Any] = {
                     "chat_provider_id": pid,
                     "prompt": prompt,
                 }
@@ -305,12 +307,19 @@ async def call_provider_with_retry(
 
     # 3. 开始执行队列
     last_exc = None
-    current_response_format = response_format
+    
+    # 记录上一次尝试的 Provider ID，用于判断是否发生切换
+    previous_pid = None
 
     for i, (current_pid, is_fallback) in enumerate(attempt_queue):
         attempt_num = i + 1
         is_last_attempt = (i == len(attempt_queue) - 1)
         
+        # 修复状态污染：如果切换了全新的 Provider，必须重置 response_format 约束
+        if current_pid != previous_pid:
+            current_response_format = response_format
+        previous_pid = current_pid
+
         prefix = "[降级补偿] " if is_fallback else "[LLM 调用] "
         logger.info(
             f"{prefix}尝试 #{attempt_num} | Provider ID: {current_pid} | "
@@ -340,7 +349,10 @@ async def call_provider_with_retry(
             logger.warning(f"{prefix}请求失败: {last_exc}")
             
             if not is_last_attempt:
-                await asyncio.sleep(backoff * attempt_num)
+                # Exponential backoff with jitter: backoff * (2 ^ (attempt_num - 1)) + random jitter
+                sleep_time = backoff * (2 ** (attempt_num - 1)) + random.uniform(0, 1)
+                logger.debug(f"等待 {sleep_time:.2f} 秒后重试...")
+                await asyncio.sleep(sleep_time)
 
     logger.error(f"LLM请求队列全部耗尽，最终失败: {last_exc}")
     return None

--- a/src/infrastructure/analysis/utils/llm_utils.py
+++ b/src/infrastructure/analysis/utils/llm_utils.py
@@ -245,130 +245,104 @@ async def call_provider_with_retry(
     extra_generate_kwargs: dict[str, object] | None = None,
 ) -> object | None:
     """
-    调用LLM提供者，带超时、重试与退避。支持自定义服务商和配置化 Provider 选择。
-
-    Args:
-        context: AstrBot上下文对象
-        config_manager: 配置管理器
-        prompt: 输入的提示语
-        umo: 指定使用的模型唯一标识符
-        provider_id_key: 配置中的 provider_id 键名（如 'topic_provider_id'），用于选择特定的 Provider
-        system_prompt: 系统提示词
-        response_format: 结构化输出约束（OpenAI 风格）
-        extra_generate_kwargs: 传递给 context.llm_generate 的附加参数（用于内部高级重试策略）
-
-    Returns:
-        LLM生成的结果，失败时返回None
+    调用LLM提供者，带超时、重试与退避。支持指定模型失效后自动降级到默认模型重试。
     """
-    # 注意: 超时由 AstrBot Provider 内部配置控制，不再使用插件层 asyncio.wait_for
-    # 用户可在 AstrBot WebUI 中为每个 Provider 配置 timeout 参数
     retries = config_manager.get_llm_retries()
     backoff = config_manager.get_llm_backoff()
-
-    # 检查流式调用配置
     enable_streaming_llm_call = config_manager.get_enable_streaming_llm_call()
 
-    last_exc = None
-    for attempt in range(1, retries + 1):
+    # 1. 确定我们要尝试的 Provider 队列
+    attempt_queue = []
+    
+    # 尝试获取指定的 Provider
+    specific_provider_id = await get_provider_id_with_fallback(
+        context, config_manager, provider_id_key, umo
+    )
+    if specific_provider_id:
+        attempt_queue.extend([(specific_provider_id, False)] * retries)
+
+    # 尝试获取降级/默认的 Provider (传入 None 走主模型/会话模型路径)
+    if provider_id_key is not None:
+        fallback_provider_id = await get_provider_id_with_fallback(
+            context, config_manager, None, umo
+        )
+        if fallback_provider_id and fallback_provider_id != specific_provider_id:
+            attempt_queue.extend([(fallback_provider_id, True)] * retries)
+            
+    if not attempt_queue:
+        logger.error("无可用 Provider，无法调用 llm_generate")
+        return None
+
+    # 2. 核心请求执行闭包
+    async def _execute_llm_request(pid: str, r_format: JSONObject | None):
+        cb = _get_circuit_breaker(pid)
+        if not cb.allow_request():
+            logger.warning(f"Provider {pid} 熔断器已打开，跳过本次请求")
+            raise Exception("Circuit breaker open")
+
         try:
-            # 使用新的 provider 选择逻辑，获取 Provider ID
-            provider_id = await get_provider_id_with_fallback(
-                context, config_manager, provider_id_key, umo
-            )
+            async with GlobalRateLimiter.get_instance().semaphore:
+                llm_kwargs: dict[str, object] = {
+                    "chat_provider_id": pid,
+                    "prompt": prompt,
+                }
+                if system_prompt is not None:
+                    llm_kwargs["system_prompt"] = system_prompt
+                if r_format is not None:
+                    llm_kwargs["response_format"] = r_format
+                if extra_generate_kwargs:
+                    llm_kwargs.update(extra_generate_kwargs)
 
-            if not provider_id:
-                logger.error("provider_id 为空，无法调用 llm_generate，直接返回 None")
-                return None
+                if enable_streaming_llm_call:
+                    resp = await _call_provider_stream(context, pid, llm_kwargs)
+                else:
+                    resp = await context.llm_generate(**llm_kwargs)
+            cb.record_success()
+            return resp
+        except Exception as err:
+            cb.record_failure()
+            raise err
 
-            logger.info(
-                f"[LLM 调用] 使用 Provider ID: {provider_id} | "
-                "max_tokens=provider-default | "
-                "temperature=provider-default | "
-                f"prompt长度={len(prompt) if prompt else 0}字符"
-            )
+    # 3. 开始执行队列
+    last_exc = None
+    current_response_format = response_format
 
-            logger.debug(
-                f"[LLM 调用] Prompt 前100字符: {prompt[:100] if prompt else 'None'}..."
-            )
+    for i, (current_pid, is_fallback) in enumerate(attempt_queue):
+        attempt_num = i + 1
+        is_last_attempt = (i == len(attempt_queue) - 1)
+        
+        prefix = "[降级补偿] " if is_fallback else "[LLM 调用] "
+        logger.info(
+            f"{prefix}尝试 #{attempt_num} | Provider ID: {current_pid} | "
+            f"prompt长度={len(prompt) if prompt else 0}字符"
+        )
+        
+        if not prompt or not prompt.strip():
+            logger.error("LLM provider: prompt 为空，无法调用")
+            return None
 
-            if system_prompt:
-                logger.debug(
-                    f"[LLM 调用] System Prompt 前100字符: {system_prompt[:100]}..."
-                )
-
-            # 检查 prompt 是否为空
-            if not prompt or not prompt.strip():
-                logger.error(
-                    "LLM provider: prompt 为空或只包含空白字符，无法调用 llm_generate"
-                )
-                return None
-
-            # 获取熔断器
-            cb = _get_circuit_breaker(provider_id)
-            if not cb.allow_request():
-                logger.warning(f"Provider {provider_id} 熔断器已打开，跳过本次请求")
-                return None
-
-            # 使用全局限流器 + 熔断器记录
-            # 超时由 Provider 内部控制，无需外层 wait_for
-            try:
-                async with GlobalRateLimiter.get_instance().semaphore:
-                    llm_kwargs: dict[str, object] = {
-                        "chat_provider_id": provider_id,
-                        "prompt": prompt,
-                    }
-                    if system_prompt is not None:
-                        llm_kwargs["system_prompt"] = system_prompt
-                    if response_format is not None:
-                        llm_kwargs["response_format"] = response_format
-                    if extra_generate_kwargs:
-                        llm_kwargs.update(extra_generate_kwargs)
-
-                    if enable_streaming_llm_call:
-                        logger.info("[LLM 调用] 使用流式 Provider 调用")
-
-                    async def _invoke_llm(pid: str):
-                        if enable_streaming_llm_call:
-                            return await _call_provider_stream(context, pid, llm_kwargs)
-                        return await context.llm_generate(**llm_kwargs)
-
-                    try:
-                        llm_resp = await _invoke_llm(provider_id)
-                    except Exception as e:
-                        if (
-                            response_format is not None
-                            and _is_response_format_unsupported_error(e)
-                        ):
-                            logger.warning(
-                                "[LLM 调用] 当前 Provider 可能不支持 response_format，"
-                                "已自动降级为无 schema 约束重试本次请求。"
-                            )
-                            llm_kwargs.pop("response_format", None)
-                            llm_resp = await _invoke_llm(provider_id)
-                        else:
-                            raise
-
-                # 成功记录
-                cb.record_success()
-                return llm_resp
-
-            except Exception as e:
-                # 失败记录
-                cb.record_failure()
-                raise e
-
-        except asyncio.TimeoutError as e:
-            last_exc = e
-            logger.warning(f"LLM请求超时: 第{attempt}次 (Provider 内部超时)")
+        try:
+            return await _execute_llm_request(current_pid, current_response_format)
+            
         except Exception as e:
             last_exc = e
-            logger.warning(f"LLM请求失败: 第{attempt}次, 错误: {last_exc}")
-        # 若非最后一次，等待退避后重试
-        if attempt < retries:
-            await asyncio.sleep(backoff * attempt)
+            
+            # 处理不支持 response_format 的情况
+            if current_response_format is not None and _is_response_format_unsupported_error(e):
+                logger.warning(f"{prefix}当前 Provider 可能不支持 response_format，已自动降级为无 schema 约束。")
+                current_response_format = None
+                # 在当前尝试额度内立即再试一次剥离了 schema 的请求
+                try:
+                    return await _execute_llm_request(current_pid, current_response_format)
+                except Exception as inner_e:
+                    last_exc = inner_e
+            
+            logger.warning(f"{prefix}请求失败: {last_exc}")
+            
+            if not is_last_attempt:
+                await asyncio.sleep(backoff * attempt_num)
 
-    # 最终仍失败，记录错误并返回 None 由调用方处理降级，避免抛出异常
-    logger.error(f"LLM请求全部重试失败: {last_exc}")
+    logger.error(f"LLM请求队列全部耗尽，最终失败: {last_exc}")
     return None
 
 

--- a/src/infrastructure/analysis/utils/llm_utils.py
+++ b/src/infrastructure/analysis/utils/llm_utils.py
@@ -248,8 +248,23 @@ async def call_provider_with_retry(
     extra_generate_kwargs: dict[str, JSONValue] | None = None,
 ) -> LLMResponse | None:
     """
-    调用LLM提供者，带超时、重试与退避。支持指定模型失效后自动降级到默认模型重试。
+    调用LLM提供者，带超时、重试与退避。支持自定义服务商和配置化 Provider 选择。
+
+    Args:
+        context: AstrBot上下文对象
+        config_manager: 配置管理器
+        prompt: 输入的提示语
+        umo: 指定使用的模型唯一标识符
+        provider_id_key: 配置中的 provider_id 键名（如 'topic_provider_id'），用于选择特定的 Provider
+        system_prompt: 系统提示词
+        response_format: 结构化输出约束（OpenAI 风格）
+        extra_generate_kwargs: 传递给 context.llm_generate 的附加参数（用于内部高级重试策略）
+
+    Returns:
+        LLM生成的结果，失败时返回None
     """
+    # 注意: 超时由 AstrBot Provider 内部配置控制，不再使用插件层 asyncio.wait_for
+    # 用户可在 AstrBot WebUI 中为每个 Provider 配置 timeout 参数
     retries = config_manager.get_llm_retries()
     backoff = config_manager.get_llm_backoff()
     enable_streaming_llm_call = config_manager.get_enable_streaming_llm_call()

--- a/src/infrastructure/analysis/utils/llm_utils.py
+++ b/src/infrastructure/analysis/utils/llm_utils.py
@@ -255,7 +255,7 @@ async def call_provider_with_retry(
 
     # 1. 确定我们要尝试的 Provider 队列
     attempt_queue = []
-    
+
     # 尝试获取指定的 Provider
     specific_provider_id = await get_provider_id_with_fallback(
         context, config_manager, provider_id_key, umo
@@ -270,7 +270,7 @@ async def call_provider_with_retry(
         )
         if fallback_provider_id and fallback_provider_id != specific_provider_id:
             attempt_queue.extend([(fallback_provider_id, True)] * retries)
-            
+
     if not attempt_queue:
         logger.error("无可用 Provider，无法调用 llm_generate")
         return None
@@ -302,19 +302,21 @@ async def call_provider_with_retry(
             cb.record_success()
             return resp
         except Exception as err:
+            if r_format is not None and _is_response_format_unsupported_error(err):
+                raise err
             cb.record_failure()
             raise err
 
     # 3. 开始执行队列
     last_exc = None
-    
+
     # 记录上一次尝试的 Provider ID，用于判断是否发生切换
     previous_pid = None
 
     for i, (current_pid, is_fallback) in enumerate(attempt_queue):
         attempt_num = i + 1
         is_last_attempt = (i == len(attempt_queue) - 1)
-        
+
         # 修复状态污染：如果切换了全新的 Provider，必须重置 response_format 约束
         if current_pid != previous_pid:
             current_response_format = response_format
@@ -325,17 +327,17 @@ async def call_provider_with_retry(
             f"{prefix}尝试 #{attempt_num} | Provider ID: {current_pid} | "
             f"prompt长度={len(prompt) if prompt else 0}字符"
         )
-        
+
         if not prompt or not prompt.strip():
             logger.error("LLM provider: prompt 为空，无法调用")
             return None
 
         try:
             return await _execute_llm_request(current_pid, current_response_format)
-            
+
         except Exception as e:
             last_exc = e
-            
+
             # 处理不支持 response_format 的情况
             if current_response_format is not None and _is_response_format_unsupported_error(e):
                 logger.warning(f"{prefix}当前 Provider 可能不支持 response_format，已自动降级为无 schema 约束。")
@@ -345,9 +347,9 @@ async def call_provider_with_retry(
                     return await _execute_llm_request(current_pid, current_response_format)
                 except Exception as inner_e:
                     last_exc = inner_e
-            
+
             logger.warning(f"{prefix}请求失败: {last_exc}")
-            
+
             if not is_last_attempt:
                 # Exponential backoff with jitter: backoff * (2 ^ (attempt_num - 1)) + random jitter
                 sleep_time = backoff * (2 ** (attempt_num - 1)) + random.uniform(0, 1)

--- a/src/infrastructure/analysis/utils/llm_utils.py
+++ b/src/infrastructure/analysis/utils/llm_utils.py
@@ -307,6 +307,7 @@ async def call_provider_with_retry(
 
     # 3. 开始执行队列
     last_exc = None
+    current_response_format = response_format
 
     # 记录上一次尝试的 Provider ID，用于判断是否发生切换
     previous_pid = None


### PR DESCRIPTION
### 问题描述

当在配置中指定了专属的 `topic_provider_id` 等模型时，如果该模型虽然存在、但运行时不可用（如遇到 429 限流、401 鉴权失败、服务端无容量或 Key 冷却），原始逻辑会在该模型上耗尽所有重试次数并放弃分析，不会继续降级到默认模型。

### 修复与重构方案（基于统一尝试队列）

本次更新对重试逻辑进行了彻底重构，放弃了初版的补丁式改法。

**逻辑说明：**
将 `[指定模型重试N次]` 和 `[降级默认模型重试N次]` 组合成一个统一的 `attempt_queue` 队列。并将核心的并发限流、断路器、请求组装代码提取为独立的闭包 `_execute_llm_request`。

**优势与深度优化：**
1. **彻底消除重复代码**：符合 DRY 原则，主循环极其干净。
2. **指数退避与抖动 (Exponential Backoff with Jitter)**：将原有的线性重试等待升级为带有随机抖动的指数退避算法，极大增强了在面临高并发 API `429` 限流时的抗拥塞恢复能力，防止惊群效应。
3. **修复状态污染 (State Bleeding)**：修复了当首个模型因不支持 `response_format` 触发异常后，会将该参数永久置空，导致后续降级模型（即使支持 JSON）也永久丢失强制结构化输出能力的问题。现已确保在切换 Provider 时精准重置格式约束状态。
4. **避免误触发熔断器**：当 Provider 仅是不兼容 `response_format`、但去掉 schema 后可正常响应时，不再把第一次兼容性异常计入熔断器失败，避免把可用 Provider 误判为故障 Provider。
5. **同步配置说明**：`llm_backoff` 的配置提示已同步为指数退避与随机抖动，避免 UI 仍描述为旧的线性退避策略。
6. **规范化类型提示**：将相关函数的参数类型从 `dict[str, object]` 规范化为 `dict[str, Any]`。
7. **保证任务连贯性**：即使指定模型彻底瘫痪，也能安全地滑落到系统默认模型进行兜底，确保当天的群分析报告正常生成。

---

### 💡 未来优化探讨 (关于 401/404 等致命错误)

目前的队列降级是“无差别尝试”（哪怕是配错了 Key 导致 401，也会执行退避等待后重试）。

理想状态下，可以引入**基于错误分类的智能路由**：例如捕获到鉴权失败或模型不存在时，直接跳过当前模型剩余的重试额度，秒切默认模型以节省时间。但考虑到目前各大 Provider 抛出的异常结构各不相同，为了保证当前底层逻辑的绝对稳定，本次 PR 选择使用最稳健的队列逐一尝试法。如果未来框架层提供了标准化的统一错误码对象，可在此思路上继续优化。
