### PR TITLE
feat(comic): 支持通用生图与大香蕉外部绘图后端，可配置回退策略

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,11 @@ _✨ 一个基于 AstrBot 的智能群聊分析插件，支持 **OneBot** ( [Nap
 每日群漫画不按自然日限流：每次成功得到群分析结果时都会尝试生成一张。手动群分析、定时传统分析、定时增量最终报告，以及开启“增量分析立即报告”后的即时增量最终报告都适用。同一群已有漫画在排队或生成时，新请求会直接跳过，避免重复出图；不同群仍受漫画并发配置限制。
 
 1. 在 `每日群漫画` 配置组开启 `enable_daily_comic`，并在 `分析功能` 配置组保持 `topic_analysis_enabled` 开启。
-2. 填写 `drawing_api_url`、`drawing_api_key`、`drawing_model` 和 `drawing_api_protocol`。协议必须与上游接口一致：OpenAI Images 用 `images`，OpenAI 兼容聊天接口用 `chat`，xAI Grok Imagine 用 `grok`，Google Gemini Interactions 用 `gemini`。
-3. 可选填写 `drawing_prompt_provider_id`。它用于把分析结果整理成绘图分镜提示词；留空时使用插件的常规 Provider 回退策略。
-4. 可选在 `漫画参考图` 中上传 `jpg`、`jpeg`、`png` 或 `webp`，再点击目标文件的 `+` 加入配置。列表中最后加入的一张作为当前图生图参考图。
-5. 按上游能力调整 `drawing_image_size`、`drawing_aspect_ratio`、`drawing_output_format`、`drawing_timeout` 和重试项；没有参考图也可以文生图。
+2. 选择绘图后端 `drawing_backend`：`builtin`（默认，使用本插件内置绘图客户端）；`general_plugin`（调用 [「通用生图」插件](https://github.com/Railgun19457/astrbot_plugin_image_generation) 公共 API）；`big_banana`（调用 [「大香蕉」插件](https://github.com/sukafon/astrbot_plugin_big_banana) 绘图管线）。使用外部后端时需在对应插件中配置其自身的 API/提供商；外部后端支持流式/异步请求，可规避慢模型撞上游网关超时。外部后端失败时由 `drawing_external_fallback` 决定是否回退内置后端（默认回退，关闭则直接取消本次漫画）。
+3. 内置后端填写 `drawing_api_url`、`drawing_api_key`、`drawing_model` 和 `drawing_api_protocol`。协议必须与上游接口一致：OpenAI Images 用 `images`，OpenAI 兼容聊天接口用 `chat`，xAI Grok Imagine 用 `grok`，Google Gemini Interactions 用 `gemini`。
+4. 可选填写 `drawing_prompt_provider_id`。它用于把分析结果整理成绘图分镜提示词；留空时使用插件的常规 Provider 回退策略。
+5. 可选在 `漫画参考图` 中上传 `jpg`、`jpeg`、`png` 或 `webp`，再点击目标文件的 `+` 加入配置。列表中最后加入的一张作为当前图生图参考图。
+6. 按上游能力调整 `drawing_image_size`、`drawing_aspect_ratio`、`drawing_output_format`、`drawing_timeout` 和重试项；没有参考图也可以文生图。
 
 分析结果完成后，漫画任务会立即在后台运行，报告渲染与发送不会等待出图完成。反过来，报告发送失败也不会取消已经开始的漫画任务。漫画只使用有效的话题总结作为分镜素材，因此需要开启话题分析；话题功能关闭、话题 LLM 无结果或标题为空时，插件仅记录调试日志并跳过本次漫画。
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -468,9 +468,15 @@
             "drawing_backend": {
                 "description": "绘图后端",
                 "type": "string",
-                "options": ["builtin", "general_plugin"],
+                "options": ["builtin", "general_plugin", "big_banana"],
                 "default": "builtin",
-                "hint": "builtin=使用本插件内置绘图客户端（非流式请求，慢模型可能撞上游网关超时）；general_plugin=调用已安装的「通用生图」插件的公共 API（流式+异步任务，可规避网关超时）。使用通用生图后端时，需先在通用生图插件中配置其自身的 API；未安装/未激活/调用失败时自动回退内置后端。"
+                "hint": "builtin=使用本插件内置绘图客户端（非流式请求，慢模型可能撞上游网关超时）；general_plugin=调用已安装的「通用生图」插件的公共 API（流式+异步任务）；big_banana=调用已安装的「大香蕉」插件的绘图管线（支持 Gemini/SiliconFlow 等及流式响应）。使用外部后端时，需先在对应插件中配置其自身的 API/提供商；未安装、未激活或调用失败时自动回退内置后端。"
+            },
+            "drawing_external_fallback": {
+                "description": "外部后端失败时回退内置后端",
+                "type": "bool",
+                "default": true,
+                "hint": "使用通用生图/大香蕉外部绘图后端时，若其未安装、未激活或生成失败，是否自动回退到本插件内置绘图客户端；关闭后失败将直接取消本次漫画生成。"
             },
             "drawing_api_url": {
                 "description": "绘图 API URL",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -465,6 +465,13 @@
                 "file_types": ["jpg", "jpeg", "png", "webp"],
                 "hint": "上传后点击 + 将图片设为参考图。已添加多张时，最后添加的一张会用于图生图。"
             },
+            "drawing_backend": {
+                "description": "绘图后端",
+                "type": "string",
+                "options": ["builtin", "general_plugin"],
+                "default": "builtin",
+                "hint": "builtin=使用本插件内置绘图客户端（非流式请求，慢模型可能撞上游网关超时）；general_plugin=调用已安装的「通用生图」插件的公共 API（流式+异步任务，可规避网关超时）。使用通用生图后端时，需先在通用生图插件中配置其自身的 API；未安装/未激活/调用失败时自动回退内置后端。"
+            },
             "drawing_api_url": {
                 "description": "绘图 API URL",
                 "type": "string",

--- a/main.py
+++ b/main.py
@@ -129,6 +129,7 @@ class GroupDailyAnalysis(Star):
             self.drawing_client,
             self.config_manager,
             plugin_data_dir,
+            context=context,
         )
 
         # 消息处理服务

--- a/src/application/services/comic_application_service.py
+++ b/src/application/services/comic_application_service.py
@@ -1,6 +1,8 @@
 import mimetypes
 from pathlib import Path
 
+from astrbot.api.star import Context
+
 from ...infrastructure.analysis.llm_analyzer import LLMAnalyzer
 from ...infrastructure.config.config_manager import ConfigManager
 from ...infrastructure.drawing.drawing_client import (
@@ -24,11 +26,13 @@ class ComicApplicationService:
         drawing_client: DrawingClient,
         config_manager: ConfigManager,
         plugin_data_dir: Path,
+        context: Context | None = None,
     ):
         self.llm_analyzer = llm_analyzer
         self.drawing_client = drawing_client
         self.config_manager = config_manager
         self.plugin_data_dir = plugin_data_dir
+        self.context = context
 
     async def generate_comic(
         self,
@@ -83,7 +87,19 @@ class ComicApplicationService:
                     f"[Comic] 无法加载 WebUI 参考图: {Path(reference_image_path).name}，将不使用参考图。"
                 )
 
-        # 4. 调用绘图 API，捕获"有 URL 但下载失败"的情况
+        # 4. 若配置为通用生图后端，优先走「通用生图」插件公共 API（流式/异步，避免网关超时）
+        if self.config_manager.get_drawing_backend() == "general_plugin":
+            general_comic_bytes = await self._generate_via_general_plugin(
+                scene_prompt, images_data
+            )
+            if general_comic_bytes:
+                logger.info(
+                    f"[Comic] 漫画生成成功（通用生图后端），大小: {len(general_comic_bytes)} bytes"
+                )
+                return general_comic_bytes, None
+            logger.warning("[Comic] 通用生图后端未产出结果，回退内置绘图后端。")
+
+        # 5. 调用内置绘图 API，捕获"有 URL 但下载失败"的情况
         fallback_url: str | None = None
         try:
             final_comic_bytes, last_error = await self.drawing_client.generate_image(
@@ -127,6 +143,79 @@ class ComicApplicationService:
             logger.error("[Comic] 漫画生成最终失败。")
 
         return final_comic_bytes, fallback_url
+
+    async def _generate_via_general_plugin(
+        self,
+        scene_prompt: str,
+        images_data: list[tuple[bytes, str]] | None,
+    ) -> bytes | None:
+        """通过「通用生图」插件的公共 API 生成漫画。
+
+        通用生图插件内部使用流式/异步轮询，可规避非流式请求撞上游网关超时 (HTTP 504)。
+        未安装、未激活、未配置 API 或调用失败时返回 None，由调用方回退内置 DrawingClient。
+
+        Returns:
+            生成图片的二进制数据；失败时返回 None。
+        """
+        if self.context is None:
+            logger.debug("[Comic] 未注入插件 Context，跳过通用生图后端。")
+            return None
+        try:
+            meta = self.context.get_registered_star(
+                "astrbot_plugin_image_generation"
+            )
+        except Exception as exc:
+            logger.debug(f"[Comic] 获取通用生图插件注册信息失败: {exc}")
+            return None
+        image_plugin = meta.star_cls if meta and meta.activated else None
+        if image_plugin is None:
+            logger.warning("[Comic] 未检测到已激活的「通用生图」插件，回退内置绘图后端。")
+            return None
+
+        public_api = getattr(image_plugin, "public_api", None)
+        if public_api is None:
+            logger.warning("[Comic] 通用生图插件未暴露 public_api，回退内置绘图后端。")
+            return None
+
+        try:
+            logger.info("[Comic] 通过「通用生图」插件公共 API 生成漫画...")
+            result = await public_api.generate_image_files(
+                prompt=scene_prompt,
+                source="群分析插件",
+                aspect_ratio=self.config_manager.get_drawing_aspect_ratio(),
+                reference_image_data=images_data,
+                timeout_seconds=self.config_manager.get_drawing_timeout(),
+            )
+        except Exception as exc:
+            logger.error(f"[Comic] 通用生图后端调用异常: {exc}")
+            return None
+
+        if not getattr(result, "ok", False):
+            code = str(getattr(result, "code", ""))
+            message = getattr(result, "message", "") or getattr(result, "error", "")
+            hint = ""
+            if code == "prompt_blocked":
+                hint = "（提示词被通用生图插件安全审核拦截，可调整其审核配置或精简 scene 提示词）"
+            elif code == "api_key_missing":
+                hint = "（通用生图插件未配置 API Key，需先在通用生图插件中配置）"
+            elif code == "timeout":
+                hint = "（等待通用生图任务结果超时）"
+            elif code == "rate_limited":
+                hint = "（命中通用生图插件额度/频率限制）"
+            logger.warning(f"[Comic] 通用生图后端失败 [{code}]: {message}{hint}")
+            return None
+
+        paths = list(getattr(result, "paths", None) or [])
+        if not paths:
+            logger.warning(
+                "[Comic] 通用生图后端未返回图片路径（可能参考图被忽略或结果为空，请检查通用生图插件配置与参考图大小限制）。"
+            )
+            return None
+        try:
+            return Path(paths[0]).read_bytes()
+        except OSError as exc:
+            logger.warning(f"[Comic] 读取通用生图后端结果失败: {exc}")
+            return None
 
     async def _fetch_reference_image(
         self, relative_path: str

--- a/src/application/services/comic_application_service.py
+++ b/src/application/services/comic_application_service.py
@@ -182,15 +182,15 @@ class ComicApplicationService:
             logger.debug("[Comic] 未注入插件 Context，跳过通用生图后端。")
             return None
         try:
-            meta = self.context.get_registered_star(
-                "astrbot_plugin_image_generation"
-            )
+            meta = self.context.get_registered_star("astrbot_plugin_image_generation")
         except Exception as exc:
             logger.debug(f"[Comic] 获取通用生图插件注册信息失败: {exc}")
             return None
         image_plugin = meta.star_cls if meta and meta.activated else None
         if image_plugin is None:
-            logger.warning("[Comic] 未检测到已激活的「通用生图」插件，回退内置绘图后端。")
+            logger.warning(
+                "[Comic] 未检测到已激活的「通用生图」插件，回退内置绘图后端。"
+            )
             return None
 
         public_api = getattr(image_plugin, "public_api", None)
@@ -282,7 +282,9 @@ class ComicApplicationService:
                 if resource:
                     image_list.append(resource)
             if not image_list:
-                logger.warning("[Comic] 参考图无法解析为「大香蕉」图片资源，将不带参考图生成。")
+                logger.warning(
+                    "[Comic] 参考图无法解析为「大香蕉」图片资源，将不带参考图生成。"
+                )
 
         params: dict[str, Any] = {
             "prompt": scene_prompt,
@@ -339,9 +341,7 @@ class ComicApplicationService:
         module_name = getattr(type(plugin), "__module__", "") or ""
         candidate_modules = []
         if module_name and "." in module_name:
-            candidate_modules.append(
-                module_name.rsplit(".", 1)[0] + ".core.schemas"
-            )
+            candidate_modules.append(module_name.rsplit(".", 1)[0] + ".core.schemas")
         candidate_modules.append("astrbot_plugin_big_banana.core.schemas")
 
         for module_path in candidate_modules:

--- a/src/application/services/comic_application_service.py
+++ b/src/application/services/comic_application_service.py
@@ -111,7 +111,16 @@ class ComicApplicationService:
                 return None, None
             logger.warning(f"[Comic] {backend} 后端未产出结果，回退内置绘图后端。")
 
-        # 5. 调用内置绘图 API，捕获"有 URL 但下载失败"的情况
+        # 5. 内置绘图后端未配置时直接取消，避免向默认地址发送空请求
+        api_url = (self.config_manager.get_drawing_api_url() or "").strip()
+        api_key = (self.config_manager.get_drawing_api_key() or "").strip()
+        if not api_url and not api_key:
+            logger.warning(
+                "[Comic] 未配置绘图 API（drawing_api_url/drawing_api_key），取消漫画生成。"
+            )
+            return None, None
+
+        # 6. 调用内置绘图 API，捕获"有 URL 但下载失败"的情况
         fallback_url: str | None = None
         try:
             final_comic_bytes, last_error = await self.drawing_client.generate_image(

--- a/src/application/services/comic_application_service.py
+++ b/src/application/services/comic_application_service.py
@@ -1,5 +1,6 @@
 import mimetypes
 from pathlib import Path
+from typing import Any
 
 from astrbot.api.star import Context
 
@@ -87,17 +88,28 @@ class ComicApplicationService:
                     f"[Comic] 无法加载 WebUI 参考图: {Path(reference_image_path).name}，将不使用参考图。"
                 )
 
-        # 4. 若配置为通用生图后端，优先走「通用生图」插件公共 API（流式/异步，避免网关超时）
-        if self.config_manager.get_drawing_backend() == "general_plugin":
-            general_comic_bytes = await self._generate_via_general_plugin(
-                scene_prompt, images_data
-            )
-            if general_comic_bytes:
-                logger.info(
-                    f"[Comic] 漫画生成成功（通用生图后端），大小: {len(general_comic_bytes)} bytes"
+        # 4. 若配置为外部绘图后端，优先走对应插件（流式/异步，避免网关超时）
+        backend = self.config_manager.get_drawing_backend()
+        if backend in {"general_plugin", "big_banana"}:
+            if backend == "general_plugin":
+                external_comic_bytes = await self._generate_via_general_plugin(
+                    scene_prompt, images_data
                 )
-                return general_comic_bytes, None
-            logger.warning("[Comic] 通用生图后端未产出结果，回退内置绘图后端。")
+            else:
+                external_comic_bytes = await self._generate_via_big_banana(
+                    scene_prompt, images_data
+                )
+            if external_comic_bytes:
+                logger.info(
+                    f"[Comic] 漫画生成成功（{backend} 后端），大小: {len(external_comic_bytes)} bytes"
+                )
+                return external_comic_bytes, None
+            if not self.config_manager.get_drawing_external_fallback():
+                logger.warning(
+                    f"[Comic] {backend} 后端未产出结果，且已禁用回退内置后端，取消漫画生成。"
+                )
+                return None, None
+            logger.warning(f"[Comic] {backend} 后端未产出结果，回退内置绘图后端。")
 
         # 5. 调用内置绘图 API，捕获"有 URL 但下载失败"的情况
         fallback_url: str | None = None
@@ -216,6 +228,99 @@ class ComicApplicationService:
         except OSError as exc:
             logger.warning(f"[Comic] 读取通用生图后端结果失败: {exc}")
             return None
+
+    async def _generate_via_big_banana(
+        self,
+        scene_prompt: str,
+        images_data: list[tuple[bytes, str]] | None,
+    ) -> bytes | None:
+        """通过「大香蕉」插件的绘图管线生成漫画。
+
+        大香蕉支持 Gemini、SiliconFlow、OpenAI 等提供商及流式响应，
+        可规避内置非流式请求撞上游网关超时 (HTTP 504)。
+
+        Returns:
+            生成图片的二进制数据；失败时返回 None。
+        """
+        if self.context is None:
+            logger.debug("[Comic] 未注入插件 Context，跳过「大香蕉」后端。")
+            return None
+        try:
+            meta = self.context.get_registered_star("astrbot_plugin_big_banana")
+        except Exception as exc:
+            logger.debug(f"[Comic] 获取「大香蕉」插件注册信息失败: {exc}")
+            return None
+        plugin = meta.star_cls if meta and meta.activated else None
+        if plugin is None:
+            logger.warning("[Comic] 未检测到已激活的「大香蕉」插件，回退内置绘图后端。")
+            return None
+
+        drawing_pipeline = getattr(plugin, "drawing_pipeline", None)
+        if drawing_pipeline is None:
+            logger.warning("[Comic] 「大香蕉」插件未初始化绘图管线，回退内置绘图后端。")
+            return None
+
+        try:
+            from astrbot_plugin_big_banana.core.schemas import ImageResource
+        except Exception as exc:
+            logger.warning(f"[Comic] 无法导入「大香蕉」图片资源类型: {exc}")
+            return None
+
+        image_list = None
+        if images_data:
+            image_list = []
+            for img_bytes, _mime in images_data:
+                resource = ImageResource.from_bytes(img_bytes)
+                if resource:
+                    image_list.append(resource)
+            if not image_list:
+                logger.warning("[Comic] 参考图无法解析为「大香蕉」图片资源，将不带参考图生成。")
+
+        params: dict[str, Any] = {
+            "prompt": scene_prompt,
+            "capability": "image_generation",
+            "sub_brain": False,
+            "url": False,
+            "aspect_ratio": self.config_manager.get_drawing_aspect_ratio(),
+            "image_size": self._map_comic_image_size(
+                self.config_manager.get_drawing_image_size()
+            ),
+        }
+
+        try:
+            logger.info("[Comic] 通过「大香蕉」插件绘图管线生成漫画...")
+            result = await drawing_pipeline.run(params, image_list)
+        except Exception as exc:
+            logger.error(f"[Comic] 「大香蕉」绘图管线调用异常: {exc}")
+            return None
+
+        if getattr(result, "error_message", None):
+            logger.warning(f"[Comic] 「大香蕉」生成失败: {result.error_message}")
+            return None
+
+        images = getattr(result, "images", None) or []
+        if not images:
+            logger.warning("[Comic] 「大香蕉」未返回图片。")
+            return None
+        try:
+            image_bytes = images[0].bytes
+        except Exception as exc:
+            logger.warning(f"[Comic] 读取「大香蕉」生成结果失败: {exc}")
+            return None
+        if not image_bytes:
+            logger.warning("[Comic] 「大香蕉」返回的图片为空。")
+            return None
+        return image_bytes
+
+    @staticmethod
+    def _map_comic_image_size(size: str) -> str:
+        """将群分析插件尺寸配置映射为「大香蕉」image_size 别名。"""
+        s = (size or "").strip().lower()
+        if s in {"2k", "2048x2048", "2048"}:
+            return "2K"
+        if s in {"4k", "3840x3840", "4096x4096"}:
+            return "4K"
+        return "1K"
 
     async def _fetch_reference_image(
         self, relative_path: str

--- a/src/application/services/comic_application_service.py
+++ b/src/application/services/comic_application_service.py
@@ -260,10 +260,9 @@ class ComicApplicationService:
             logger.warning("[Comic] 「大香蕉」插件未初始化绘图管线，回退内置绘图后端。")
             return None
 
-        try:
-            from astrbot_plugin_big_banana.core.schemas import ImageResource
-        except Exception as exc:
-            logger.warning(f"[Comic] 无法导入「大香蕉」图片资源类型: {exc}")
+        ImageResource = self._import_big_banana_image_resource(plugin)
+        if ImageResource is None:
+            logger.warning("[Comic] 无法导入「大香蕉」图片资源类型，回退内置绘图后端。")
             return None
 
         image_list = None
@@ -311,6 +310,40 @@ class ComicApplicationService:
             logger.warning("[Comic] 「大香蕉」返回的图片为空。")
             return None
         return image_bytes
+
+    @staticmethod
+    def _import_big_banana_image_resource(plugin: Any):
+        """导入「大香蕉」插件的 ImageResource 类型。
+
+        AstrBot 以 ``data.plugins.<插件名>.main`` 形式加载插件，模块名并非
+        ``astrbot_plugin_big_banana``，因此先从插件类的模块路径推导包名导入；
+        推导失败时回退直接导入，兼容 pip 安装或测试环境注入的场景。
+
+        Args:
+            plugin: 已激活的大香蕉插件实例。
+
+        Returns:
+            ImageResource 类型；无法导入时返回 None。
+        """
+        import importlib
+
+        module_name = getattr(type(plugin), "__module__", "") or ""
+        candidate_modules = []
+        if module_name and "." in module_name:
+            candidate_modules.append(
+                module_name.rsplit(".", 1)[0] + ".core.schemas"
+            )
+        candidate_modules.append("astrbot_plugin_big_banana.core.schemas")
+
+        for module_path in candidate_modules:
+            try:
+                schemas_module = importlib.import_module(module_path)
+            except Exception:
+                continue
+            image_resource = getattr(schemas_module, "ImageResource", None)
+            if image_resource is not None:
+                return image_resource
+        return None
 
     @staticmethod
     def _map_comic_image_size(size: str) -> str:

--- a/src/infrastructure/config/config_manager.py
+++ b/src/infrastructure/config/config_manager.py
@@ -846,9 +846,15 @@ class ConfigManager:
         return self._get_group("daily_comic").get("enable_daily_comic", False)
 
     def get_drawing_backend(self) -> str:
-        """获取漫画绘图后端 (builtin/general_plugin)。"""
+        """获取漫画绘图后端 (builtin/general_plugin/big_banana)。"""
         group = self._get_group("daily_comic")
         return str(group.get("drawing_backend", "builtin")).strip() or "builtin"
+
+    def get_drawing_external_fallback(self) -> bool:
+        """外部绘图后端失败时是否回退内置后端。"""
+        return bool(
+            self._get_group("daily_comic").get("drawing_external_fallback", True)
+        )
 
     def get_drawing_api_url(self) -> str:
         """获取绘图 API 地址，空值由所选协议补全默认地址。"""

--- a/src/infrastructure/config/config_manager.py
+++ b/src/infrastructure/config/config_manager.py
@@ -845,6 +845,11 @@ class ConfigManager:
         """获取是否开启每日群漫画功能"""
         return self._get_group("daily_comic").get("enable_daily_comic", False)
 
+    def get_drawing_backend(self) -> str:
+        """获取漫画绘图后端 (builtin/general_plugin)。"""
+        group = self._get_group("daily_comic")
+        return str(group.get("drawing_backend", "builtin")).strip() or "builtin"
+
     def get_drawing_api_url(self) -> str:
         """获取绘图 API 地址，空值由所选协议补全默认地址。"""
         return self._get_group("daily_comic").get("drawing_api_url", "")

--- a/tests/test_comic_regressions.py
+++ b/tests/test_comic_regressions.py
@@ -498,6 +498,8 @@ def test_generate_comic_falls_back_to_builtin_when_big_banana_empty():
             get_drawing_reference_image=Mock(return_value=""),
             get_drawing_output_exception_retry_keywords=Mock(return_value=[]),
             get_drawing_external_fallback=Mock(return_value=True),
+            get_drawing_api_url=Mock(return_value="https://api.openai.com/v1"),
+            get_drawing_api_key=Mock(return_value="sk-test"),
         )
         llm_analyzer = SimpleNamespace(
             analyze_comic_storyboards=AsyncMock(
@@ -540,6 +542,48 @@ def test_generate_comic_skips_builtin_when_external_fallback_disabled():
             get_drawing_backend=Mock(return_value="big_banana"),
             get_drawing_reference_image=Mock(return_value=""),
             get_drawing_external_fallback=Mock(return_value=False),
+        )
+        llm_analyzer = SimpleNamespace(
+            analyze_comic_storyboards=AsyncMock(
+                return_value=([{"scene": "comic scene prompt"}], None)
+            )
+        )
+        drawing_client = SimpleNamespace(generate_image=AsyncMock())
+        service = SimpleNamespace(
+            config_manager=config_manager,
+            llm_analyzer=llm_analyzer,
+            drawing_client=drawing_client,
+            _fetch_reference_image=AsyncMock(),
+            _generate_via_big_banana=AsyncMock(return_value=None),
+            _generate_via_general_plugin=AsyncMock(),
+        )
+
+        comic_bytes, fallback_url = await generate_comic(
+            service,
+            [{"topic": "t1", "detail": "d1"}],
+            "123456",
+            "umo",
+        )
+
+        assert comic_bytes is None
+        assert fallback_url is None
+        drawing_client.generate_image.assert_not_called()
+
+    asyncio.run(scenario())
+
+
+def test_generate_comic_skips_unconfigured_builtin_backend():
+    """外部后端失败且内置后端未配置时，应直接取消漫画，不向默认地址发空请求。"""
+    generate_comic = load_comic_service_method("generate_comic")
+
+    async def scenario():
+        config_manager = SimpleNamespace(
+            get_enable_daily_comic=Mock(return_value=True),
+            get_drawing_backend=Mock(return_value="big_banana"),
+            get_drawing_reference_image=Mock(return_value=""),
+            get_drawing_external_fallback=Mock(return_value=True),
+            get_drawing_api_url=Mock(return_value=""),
+            get_drawing_api_key=Mock(return_value=""),
         )
         llm_analyzer = SimpleNamespace(
             analyze_comic_storyboards=AsyncMock(

--- a/tests/test_comic_regressions.py
+++ b/tests/test_comic_regressions.py
@@ -3,6 +3,7 @@ import asyncio
 import mimetypes
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 
@@ -90,7 +91,7 @@ def load_comic_service_method(name: str):
     isolated_module = ast.fix_missing_locations(
         ast.Module(body=[isolated_class], type_ignores=[])
     )
-    namespace = {"Path": Path, "mimetypes": mimetypes, "logger": Mock()}
+    namespace = {"Path": Path, "mimetypes": mimetypes, "logger": Mock(), "Any": Any}
     exec(compile(isolated_module, str(service_path), "exec"), namespace)
     return getattr(namespace["ComicServiceHarness"], name)
 
@@ -342,6 +343,7 @@ def test_big_banana_backend_returns_bytes_on_success():
                 get_drawing_image_size=Mock(return_value="2K"),
             ),
             _map_comic_image_size=Mock(return_value="2K"),
+            _import_big_banana_image_resource=Mock(return_value=fake_image_resource),
         )
 
         result = await generate(
@@ -365,7 +367,7 @@ def test_big_banana_backend_returns_bytes_on_success():
 def test_big_banana_backend_returns_none_on_provider_error():
     """大香蕉提供商返回错误消息时应回退（返回 None）。"""
     generate = load_comic_service_method("_generate_via_big_banana")
-    _install_fake_big_banana_image_resource()
+    fake_image_resource = _install_fake_big_banana_image_resource()
 
     async def scenario():
         pipeline = SimpleNamespace(
@@ -388,6 +390,7 @@ def test_big_banana_backend_returns_none_on_provider_error():
                 get_drawing_image_size=Mock(return_value="1K"),
             ),
             _map_comic_image_size=Mock(return_value="1K"),
+            _import_big_banana_image_resource=Mock(return_value=fake_image_resource),
         )
 
         result = await generate(service, "prompt", None)
@@ -395,6 +398,52 @@ def test_big_banana_backend_returns_none_on_provider_error():
         assert result is None
 
     asyncio.run(scenario())
+
+
+def test_import_big_banana_image_resource_derives_package_from_module():
+    """应从插件类模块路径推导包名导入 ImageResource。"""
+    import sys
+    from types import ModuleType
+
+    loader = load_comic_service_method("_import_big_banana_image_resource")
+
+    fake_image_resource = type("ImageResource", (), {})
+    schemas = ModuleType("data.plugins.astrbot_plugin_big_banana.core.schemas")
+    schemas.ImageResource = fake_image_resource
+    core = ModuleType("data.plugins.astrbot_plugin_big_banana.core")
+    core.schemas = schemas
+    pkg = ModuleType("data.plugins.astrbot_plugin_big_banana")
+    pkg.core = core
+    sys.modules["data.plugins.astrbot_plugin_big_banana"] = pkg
+    sys.modules["data.plugins.astrbot_plugin_big_banana.core"] = core
+    sys.modules["data.plugins.astrbot_plugin_big_banana.core.schemas"] = schemas
+
+    class FakePlugin:
+        pass
+
+    FakePlugin.__module__ = "data.plugins.astrbot_plugin_big_banana.main"
+    try:
+        assert loader(FakePlugin()) is fake_image_resource
+    finally:
+        for name in list(sys.modules):
+            if name.startswith("data.plugins.astrbot_plugin_big_banana"):
+                del sys.modules[name]
+
+
+def test_import_big_banana_image_resource_returns_none_when_unavailable():
+    """无法推导包名且直接导入失败时返回 None。"""
+    import sys
+
+    for name in [
+        n
+        for n in sys.modules
+        if n == "astrbot_plugin_big_banana"
+        or n.startswith("astrbot_plugin_big_banana.")
+    ]:
+        del sys.modules[name]
+
+    loader = load_comic_service_method("_import_big_banana_image_resource")
+    assert loader(SimpleNamespace()) is None
 
 
 def test_generate_comic_prefers_big_banana_backend():

--- a/tests/test_comic_regressions.py
+++ b/tests/test_comic_regressions.py
@@ -77,7 +77,8 @@ def load_comic_service_method(name: str):
     method = next(
         node
         for node in service_class.body
-        if isinstance(node, ast.AsyncFunctionDef) and node.name == name
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+        and node.name == name
     )
     isolated_class = ast.ClassDef(
         name="ComicServiceHarness",
@@ -255,3 +256,266 @@ def test_comic_is_skipped_without_valid_topics():
     plugin._trigger_comic_generation.assert_not_called()
     assert plugin._comic_group_tasks == {}
     assert plugin._background_tasks == set()
+
+
+def _install_fake_big_banana_image_resource():
+    """向 sys.modules 注入假的大香蕉 ImageResource，供懒加载导入使用。
+
+    Returns:
+        假 ImageResource 类型，可用于断言。
+    """
+    import sys
+    from types import ModuleType
+
+    fake_image_resource = type(
+        "ImageResource",
+        (),
+        {
+            "from_bytes": staticmethod(
+                lambda data_bytes, url=None: SimpleNamespace(
+                    bytes=data_bytes, mime="image/png"
+                )
+            )
+        },
+    )
+
+    schemas = ModuleType("astrbot_plugin_big_banana.core.schemas")
+    schemas.ImageResource = fake_image_resource
+    core = ModuleType("astrbot_plugin_big_banana.core")
+    core.schemas = schemas
+    pkg = ModuleType("astrbot_plugin_big_banana")
+    pkg.core = core
+    sys.modules["astrbot_plugin_big_banana"] = pkg
+    sys.modules["astrbot_plugin_big_banana.core"] = core
+    sys.modules["astrbot_plugin_big_banana.core.schemas"] = schemas
+    return fake_image_resource
+
+
+def test_map_comic_image_size_aliases():
+    """大香蕉后端的尺寸别名映射。"""
+    mapping = load_comic_service_method("_map_comic_image_size")
+    assert mapping("1024x1024") == "1K"
+    assert mapping("1K") == "1K"
+    assert mapping("2k") == "2K"
+    assert mapping("2048x2048") == "2K"
+    assert mapping("4K") == "4K"
+    assert mapping("4096x4096") == "4K"
+    assert mapping("auto") == "1K"
+    assert mapping("") == "1K"
+
+
+def test_big_banana_backend_returns_none_when_plugin_missing():
+    """大香蕉插件未注册时应回退（返回 None）。"""
+    generate = load_comic_service_method("_generate_via_big_banana")
+    context = SimpleNamespace(get_registered_star=Mock(return_value=None))
+    service = SimpleNamespace(context=context)
+
+    result = asyncio.run(generate(service, "prompt", None))
+
+    assert result is None
+
+
+def test_big_banana_backend_returns_bytes_on_success():
+    """大香蕉绘图管线成功时应返回图片字节并带上参考图。"""
+    generate = load_comic_service_method("_generate_via_big_banana")
+    fake_image_resource = _install_fake_big_banana_image_resource()
+
+    async def scenario():
+        pipeline = SimpleNamespace(
+            run=AsyncMock(
+                return_value=SimpleNamespace(
+                    images=[SimpleNamespace(bytes=b"comic-img")],
+                    error_message=None,
+                )
+            )
+        )
+        plugin = SimpleNamespace(drawing_pipeline=pipeline)
+        context = SimpleNamespace(
+            get_registered_star=Mock(
+                return_value=SimpleNamespace(star_cls=plugin, activated=True)
+            )
+        )
+        service = SimpleNamespace(
+            context=context,
+            config_manager=SimpleNamespace(
+                get_drawing_aspect_ratio=Mock(return_value="16:9"),
+                get_drawing_image_size=Mock(return_value="2K"),
+            ),
+            _map_comic_image_size=Mock(return_value="2K"),
+        )
+
+        result = await generate(
+            service,
+            "prompt",
+            [(b"\x89PNG\r\n\x1a\nimage", "image/png")],
+        )
+
+        assert result == b"comic-img"
+        pipeline.run.assert_awaited_once()
+        call_args = pipeline.run.call_args[0]
+        params, image_list = call_args
+        assert params["aspect_ratio"] == "16:9"
+        assert params["image_size"] == "2K"
+        assert len(image_list) == 1
+        assert fake_image_resource.from_bytes is not None
+
+    asyncio.run(scenario())
+
+
+def test_big_banana_backend_returns_none_on_provider_error():
+    """大香蕉提供商返回错误消息时应回退（返回 None）。"""
+    generate = load_comic_service_method("_generate_via_big_banana")
+    _install_fake_big_banana_image_resource()
+
+    async def scenario():
+        pipeline = SimpleNamespace(
+            run=AsyncMock(
+                return_value=SimpleNamespace(
+                    images=[], error_message="provider boom"
+                )
+            )
+        )
+        plugin = SimpleNamespace(drawing_pipeline=pipeline)
+        context = SimpleNamespace(
+            get_registered_star=Mock(
+                return_value=SimpleNamespace(star_cls=plugin, activated=True)
+            )
+        )
+        service = SimpleNamespace(
+            context=context,
+            config_manager=SimpleNamespace(
+                get_drawing_aspect_ratio=Mock(return_value="16:9"),
+                get_drawing_image_size=Mock(return_value="1K"),
+            ),
+            _map_comic_image_size=Mock(return_value="1K"),
+        )
+
+        result = await generate(service, "prompt", None)
+
+        assert result is None
+
+    asyncio.run(scenario())
+
+
+def test_generate_comic_prefers_big_banana_backend():
+    """配置 big_banana 后端时优先走大香蕉，不调用内置绘图客户端。"""
+    generate_comic = load_comic_service_method("generate_comic")
+
+    async def scenario():
+        config_manager = SimpleNamespace(
+            get_enable_daily_comic=Mock(return_value=True),
+            get_drawing_backend=Mock(return_value="big_banana"),
+            get_drawing_reference_image=Mock(return_value=""),
+        )
+        llm_analyzer = SimpleNamespace(
+            analyze_comic_storyboards=AsyncMock(
+                return_value=([{"scene": "comic scene prompt"}], None)
+            )
+        )
+        drawing_client = SimpleNamespace(generate_image=AsyncMock())
+        service = SimpleNamespace(
+            config_manager=config_manager,
+            llm_analyzer=llm_analyzer,
+            drawing_client=drawing_client,
+            _fetch_reference_image=AsyncMock(),
+            _generate_via_big_banana=AsyncMock(return_value=b"comic-bytes"),
+            _generate_via_general_plugin=AsyncMock(),
+        )
+
+        comic_bytes, fallback_url = await generate_comic(
+            service,
+            [{"topic": "t1", "detail": "d1"}],
+            "123456",
+            "umo",
+        )
+
+        assert comic_bytes == b"comic-bytes"
+        assert fallback_url is None
+        service._generate_via_big_banana.assert_awaited_once()
+        service._generate_via_general_plugin.assert_not_called()
+        drawing_client.generate_image.assert_not_called()
+
+    asyncio.run(scenario())
+
+
+def test_generate_comic_falls_back_to_builtin_when_big_banana_empty():
+    """大香蕉后端无结果时应回退内置绘图客户端。"""
+    generate_comic = load_comic_service_method("generate_comic")
+
+    async def scenario():
+        config_manager = SimpleNamespace(
+            get_enable_daily_comic=Mock(return_value=True),
+            get_drawing_backend=Mock(return_value="big_banana"),
+            get_drawing_reference_image=Mock(return_value=""),
+            get_drawing_output_exception_retry_keywords=Mock(return_value=[]),
+            get_drawing_external_fallback=Mock(return_value=True),
+        )
+        llm_analyzer = SimpleNamespace(
+            analyze_comic_storyboards=AsyncMock(
+                return_value=([{"scene": "comic scene prompt"}], None)
+            )
+        )
+        drawing_client = SimpleNamespace(
+            generate_image=AsyncMock(return_value=(b"builtin-bytes", None))
+        )
+        service = SimpleNamespace(
+            config_manager=config_manager,
+            llm_analyzer=llm_analyzer,
+            drawing_client=drawing_client,
+            _fetch_reference_image=AsyncMock(),
+            _generate_via_big_banana=AsyncMock(return_value=None),
+            _generate_via_general_plugin=AsyncMock(),
+        )
+
+        comic_bytes, fallback_url = await generate_comic(
+            service,
+            [{"topic": "t1", "detail": "d1"}],
+            "123456",
+            "umo",
+        )
+
+        assert comic_bytes == b"builtin-bytes"
+        assert fallback_url is None
+        drawing_client.generate_image.assert_awaited_once()
+
+    asyncio.run(scenario())
+
+
+def test_generate_comic_skips_builtin_when_external_fallback_disabled():
+    """关闭回退开关时，外部后端失败应直接取消漫画，不调用内置客户端。"""
+    generate_comic = load_comic_service_method("generate_comic")
+
+    async def scenario():
+        config_manager = SimpleNamespace(
+            get_enable_daily_comic=Mock(return_value=True),
+            get_drawing_backend=Mock(return_value="big_banana"),
+            get_drawing_reference_image=Mock(return_value=""),
+            get_drawing_external_fallback=Mock(return_value=False),
+        )
+        llm_analyzer = SimpleNamespace(
+            analyze_comic_storyboards=AsyncMock(
+                return_value=([{"scene": "comic scene prompt"}], None)
+            )
+        )
+        drawing_client = SimpleNamespace(generate_image=AsyncMock())
+        service = SimpleNamespace(
+            config_manager=config_manager,
+            llm_analyzer=llm_analyzer,
+            drawing_client=drawing_client,
+            _fetch_reference_image=AsyncMock(),
+            _generate_via_big_banana=AsyncMock(return_value=None),
+            _generate_via_general_plugin=AsyncMock(),
+        )
+
+        comic_bytes, fallback_url = await generate_comic(
+            service,
+            [{"topic": "t1", "detail": "d1"}],
+            "123456",
+            "umo",
+        )
+
+        assert comic_bytes is None
+        assert fallback_url is None
+        drawing_client.generate_image.assert_not_called()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## 概述
为每日群漫画新增两种外部绘图后端，并支持配置外部后端失败时是否回退内置绘图客户端。

## 变更内容
- 新增 `drawing_backend` 配置（`builtin` / `general_plugin` / `big_banana`）：支持调用「通用生图」插件公共 API 或「大香蕉」插件绘图管线
- 新增 `drawing_external_fallback`：外部后端失败时是否回退内置客户端（默认开启）。
- 内置后端未配置 API 时跳过无效回退，直接取消漫画。
- 补充测试与 README 文档。


## 测试
`pytest tests/test_comic_regressions.py` 全部通过（15 项），ruff 检查通过。

## Summary by Sourcery

Integrate configurable external drawing backends into daily comic generation with graceful fallback to the builtin client when unavailable or misconfigured.

New Features:
- Add support for selecting a comic drawing backend between the builtin client, a general image generation plugin, and the Big Banana plugin.
- Introduce configuration to control whether failed external drawing attempts fall back to the builtin backend.
- Enable daily comic generation via the Big Banana plugin drawing pipeline, including image size alias mapping and optional reference images.
- Support comic generation through the general image generation plugin’s public API when available and activated.

Enhancements:
- Avoid sending requests to the builtin drawing API when its URL and key are not configured, cancelling comic generation instead.
- Wire plugin Context into the comic application service to allow runtime discovery and use of drawing plugins.

Documentation:
- Update README to document the new drawing backend options, external fallback behavior, and how to configure builtin vs plugin-based image generation.

Tests:
- Extend regression tests to cover Big Banana backend behavior, image size alias mapping, external fallback logic, and handling of unconfigured or disabled backends.